### PR TITLE
Support for default ACL's on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rust library to manipulate access control lists on macOS and Linux.
 ```rust
 use exacl::{Acl, AclOption};
 
-let acl = Acl::read("./foo/bar.txt", AclOption::default())?;
+let acl = Acl::read("./foo/bar.txt", AclOption::empty())?;
 
 for entry in &acl.entries()? {
     println!("{:?}", entry);

--- a/src/bin/exacl.rs
+++ b/src/bin/exacl.rs
@@ -46,7 +46,7 @@ fn main() {
         options |= AclOption::DEFAULT_ACL;
     }
     if opt.symlink {
-        options |= AclOption::SYMLINK_ONLY;
+        options |= AclOption::SYMLINK_ACL;
     }
 
     let exit_code = if opt.set {

--- a/src/bin/exacl.rs
+++ b/src/bin/exacl.rs
@@ -22,6 +22,9 @@ struct Opt {
     #[structopt(long)]
     set: bool,
 
+    #[structopt(short = "d", long)]
+    default: bool,
+
     #[structopt(short = "h", long)]
     symlink: bool,
 
@@ -38,11 +41,13 @@ fn main() {
 
     let opt = Opt::from_args();
 
-    let options = if opt.symlink {
-        AclOption::SYMLINK_ONLY
-    } else {
-        AclOption::default()
-    };
+    let mut options = AclOption::empty();
+    if opt.default {
+        options |= AclOption::DEFAULT_ACL;
+    }
+    if opt.symlink {
+        options |= AclOption::SYMLINK_ONLY;
+    }
 
     let exit_code = if opt.set {
         set_acl(&opt.files, options)

--- a/src/fail.rs
+++ b/src/fail.rs
@@ -1,5 +1,7 @@
 //! Error handling convenience functions.
 
+#![allow(dead_code)]
+
 use log::debug;
 use std::fmt;
 use std::io;

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -50,7 +50,7 @@ bitflags! {
         /// Linux ACL's don't use flags.
         #[cfg(any(docsrs, target_os = "linux"))]
         #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
-        const DEFAULT = 0;
+        const DEFAULT = 1;
     }
 }
 

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -47,7 +47,7 @@ bitflags! {
         #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
         const ONLY_INHERIT = np::ACL_ENTRY_ONLY_INHERIT;
 
-        /// Linux ACL's don't use flags.
+        /// Entry from a default ACL.
         #[cfg(any(docsrs, target_os = "linux"))]
         #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
         const DEFAULT = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,11 @@ impl Acl {
         let symlink_only = options.contains(AclOption::SYMLINK_ONLY);
         let default_acl = options.contains(AclOption::DEFAULT_ACL);
 
-        xacl_check(self.acl)?;
+        // Don't check ACL if it's an empty, default ACL.
+        if !default_acl || !self.empty() {
+            xacl_check(self.acl)?;
+        }
+
         xacl_set_file(path.as_ref(), self.acl, symlink_only, default_acl)
     }
 
@@ -125,6 +129,11 @@ impl Acl {
     /// Return platform-dependent textual description.
     pub fn to_platform_text(&self) -> String {
         xacl_to_text(self.acl)
+    }
+
+    /// Return true if ACL is empty.
+    pub fn empty(&self) -> bool {
+        xacl_entry_count(self.acl) == 0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@ pub struct Acl {
 
     /// Set to true if `acl` was set from the default ACL for a directory
     /// using DEFAULT_ACL option. Used to return entries with the `DEFAULT`
-    /// flag set. Value is not used on `macOS`; it's always false.
-    #[allow(dead_code)]
+    /// flag set.
+    #[cfg(target_os = "linux")]
     default_acl: bool,
 }
 
@@ -79,6 +79,7 @@ impl Acl {
 
         Ok(Acl {
             acl: acl_p,
+            #[cfg(target_os = "linux")]
             default_acl,
         })
     }
@@ -114,6 +115,7 @@ impl Acl {
 
         Ok(Acl {
             acl: ScopeGuard::into_inner(acl_p),
+            #[cfg(target_os = "linux")]
             default_acl: false,
         })
     }
@@ -131,8 +133,8 @@ impl Acl {
         #[cfg(target_os = "linux")]
         if self.default_acl {
             // Set DEFAULT flag on each entry.
-            for i in 0..entries.len() {
-                entries[i].flags |= Flag::DEFAULT;
+            for entry in &mut entries {
+                entry.flags |= Flag::DEFAULT;
             }
         }
 
@@ -144,6 +146,7 @@ impl Acl {
         let acl_p = xacl_from_text(text)?;
         Ok(Acl {
             acl: acl_p,
+            #[cfg(target_os = "linux")]
             default_acl: false,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,8 @@ pub struct Acl {
 
     /// Set to true if `acl` was set from the default ACL for a directory
     /// using DEFAULT_ACL option. Used to return entries with the `DEFAULT`
-    /// flag set.
+    /// flag set. Value is not used on `macOS`; it's always false.
+    #[allow(dead_code)]
     default_acl: bool,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ bitflags! {
     pub struct AclOption : u32 {
         /// Get/set the ACL of the symlink itself.
         const SYMLINK_ONLY = 0x01;
+
+        /// Get/set the default ACL (Linux only).
+        const DEFAULT_ACL = 0x02;
     }
 }
 
@@ -63,7 +66,9 @@ impl Acl {
     /// Read ACL for specified file.
     pub fn read<P: AsRef<Path>>(path: P, options: AclOption) -> io::Result<Acl> {
         let symlink_only = options.contains(AclOption::SYMLINK_ONLY);
-        let acl_p = xacl_get_file(path.as_ref(), symlink_only)?;
+        let default_acl = options.contains(AclOption::DEFAULT_ACL);
+
+        let acl_p = xacl_get_file(path.as_ref(), symlink_only, default_acl)?;
 
         Ok(Acl { acl: acl_p })
     }
@@ -71,9 +76,10 @@ impl Acl {
     /// Write ACL for specified file.
     pub fn write<P: AsRef<Path>>(&self, path: P, options: AclOption) -> io::Result<()> {
         let symlink_only = options.contains(AclOption::SYMLINK_ONLY);
+        let default_acl = options.contains(AclOption::DEFAULT_ACL);
 
         xacl_check(self.acl)?;
-        xacl_set_file(path.as_ref(), self.acl, symlink_only)
+        xacl_set_file(path.as_ref(), self.acl, symlink_only, default_acl)
     }
 
     /// Construct ACL from AclEntry's.

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,6 @@ use crate::flag::Flag;
 use crate::perm::Perm;
 use crate::sys::*;
 
-use log::debug;
 use nix::unistd::{self, Gid, Uid};
 use scopeguard::defer;
 use std::ffi::{c_void, CStr, CString};
@@ -65,10 +64,7 @@ impl Qualifier {
         let qualifier = match idtype {
             ID_TYPE_UID => Qualifier::User(Uid::from_raw(id_c)),
             ID_TYPE_GID => Qualifier::Group(Gid::from_raw(id_c)),
-            other => {
-                debug!("Unknown idtype {}", other);
-                Qualifier::Unknown(guid.to_string())
-            }
+            other => Qualifier::Unknown(guid.to_string()),
         };
 
         Ok(qualifier)

--- a/src/util.rs
+++ b/src/util.rs
@@ -64,7 +64,7 @@ impl Qualifier {
         let qualifier = match idtype {
             ID_TYPE_UID => Qualifier::User(Uid::from_raw(id_c)),
             ID_TYPE_GID => Qualifier::Group(Gid::from_raw(id_c)),
-            other => Qualifier::Unknown(guid.to_string()),
+            _ => Qualifier::Unknown(guid.to_string()),
         };
 
         Ok(qualifier)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -24,7 +24,7 @@ exit_status=0
 
 if [ "$arg1" = "memcheck" ]; then
     # Enable memory check command and re-run unit tests under memcheck.
-    export MEMCHECK="valgrind -q --error-exitcode=9 --leak-check=full"
+    export MEMCHECK="valgrind -q --error-exitcode=9 --leak-check=full --errors-for-leak-kinds=definite"
 
     vers=`valgrind --version`
     echo "Running tests with memcheck ($vers)"

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -257,6 +257,11 @@ fn test_write_default_acl() -> io::Result<()> {
     let default_acl = Acl::read(&dir, AclOption::DEFAULT_ACL)?;
     assert_eq!(default_acl.to_platform_text(), acl.to_platform_text());
 
+    let default_entries = default_acl.entries()?;
+    for i in 0..default_entries.len() {
+        assert_eq!(default_entries[i].flags, Flag::DEFAULT);
+    }
+
     // Test deleting a default ACL by passing an empty acl.
     let empty_acl = Acl::from_entries(&[])?;
     empty_acl.write(&dir, AclOption::DEFAULT_ACL)?;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -29,7 +29,7 @@ fn log_acl(acl: &[AclEntry]) {
 #[test]
 fn test_read_acl() -> io::Result<()> {
     let file = tempfile::NamedTempFile::new()?;
-    let acl = Acl::read(&file, AclOption::default())?;
+    let acl = Acl::read(&file, AclOption::empty())?;
     let entries = acl.entries()?;
 
     #[cfg(target_os = "macos")]
@@ -62,8 +62,8 @@ fn test_write_acl_macos() -> io::Result<()> {
 
     let file = tempfile::NamedTempFile::new()?;
     let acl = Acl::from_entries(&entries)?;
-    assert!(!acl.empty());
-    acl.write(&file, AclOption::default())?;
+    assert!(!acl.is_empty());
+    acl.write(&file, AclOption::empty())?;
 
     // Even though the last entry is a group, the `acl_to_text` representation
     // displays it as `user`.
@@ -78,7 +78,7 @@ user:AAAABBBB-CCCC-DDDD-EEEE-FFFF00002CF0:::deny,file_inherit,directory_inherit:
 "#
     );
 
-    let acl2 = Acl::read(&file, AclOption::default())?;
+    let acl2 = Acl::read(&file, AclOption::empty())?;
     let entries2 = acl2.entries()?;
 
     assert_eq!(entries2, entries);
@@ -107,7 +107,7 @@ fn test_write_acl_linux() -> io::Result<()> {
 
     let file = tempfile::NamedTempFile::new()?;
     let acl = Acl::from_entries(&entries)?;
-    acl.write(&file, AclOption::default())?;
+    acl.write(&file, AclOption::empty())?;
 
     assert_eq!(
         acl.to_platform_text(),
@@ -122,7 +122,7 @@ other::rwx
 "#
     );
 
-    let acl2 = Acl::read(&file, AclOption::default())?;
+    let acl2 = Acl::read(&file, AclOption::empty())?;
     let mut entries2 = acl2.entries()?;
 
     entries.sort();
@@ -145,9 +145,9 @@ fn test_write_acl_big() -> io::Result<()> {
 
     let file = tempfile::NamedTempFile::new()?;
     let acl = Acl::from_entries(&entries)?;
-    acl.write(&file, AclOption::default())?;
+    acl.write(&file, AclOption::empty())?;
 
-    let acl2 = Acl::read(&file, AclOption::default())?;
+    let acl2 = Acl::read(&file, AclOption::empty())?;
     let entries2 = acl2.entries()?;
 
     assert_eq!(entries2, entries);
@@ -228,7 +228,7 @@ other::rwx
 fn test_read_default_acl() -> io::Result<()> {
     let dir = tempfile::tempdir()?;
     let default_acl = Acl::read(&dir, AclOption::DEFAULT_ACL)?;
-    assert!(default_acl.empty());
+    assert!(default_acl.is_empty());
 
     Ok(())
 }
@@ -251,21 +251,21 @@ fn test_write_default_acl() -> io::Result<()> {
     let acl = Acl::from_entries(&entries)?;
     acl.write(&dir, AclOption::DEFAULT_ACL)?;
 
-    let acl2 = Acl::read(&dir, AclOption::default())?;
+    let acl2 = Acl::read(&dir, AclOption::empty())?;
     assert_ne!(acl.to_platform_text(), acl2.to_platform_text());
 
     let default_acl = Acl::read(&dir, AclOption::DEFAULT_ACL)?;
     assert_eq!(default_acl.to_platform_text(), acl.to_platform_text());
 
     let default_entries = default_acl.entries()?;
-    for i in 0..default_entries.len() {
-        assert_eq!(default_entries[i].flags, Flag::DEFAULT);
+    for entry in &default_entries {
+        assert_eq!(entry.flags, Flag::DEFAULT);
     }
 
     // Test deleting a default ACL by passing an empty acl.
     let empty_acl = Acl::from_entries(&[])?;
     empty_acl.write(&dir, AclOption::DEFAULT_ACL)?;
-    assert!(Acl::read(&dir, AclOption::DEFAULT_ACL)?.empty());
+    assert!(Acl::read(&dir, AclOption::DEFAULT_ACL)?.is_empty());
 
     Ok(())
 }
@@ -273,6 +273,6 @@ fn test_write_default_acl() -> io::Result<()> {
 #[test]
 fn test_empty_acl() -> io::Result<()> {
     let acl = Acl::from_entries(&[])?;
-    assert!(acl.empty());
+    assert!(acl.is_empty());
     Ok(())
 }

--- a/tests/testsuite_darwin.sh
+++ b/tests/testsuite_darwin.sh
@@ -474,4 +474,19 @@ testWriteAclGUID_nil() {
         "${msg//\"}"
 }
 
+testDefaultAclFails() {
+    # Test that exacl returns an error; default acl not supported on macOS.
+    msg=`$EXACL --default $DIR1 2>&1`
+    assertEquals 1 $?
+    assertEquals \
+        "File \"$DIR1\": macOS does not support default ACL" \
+        "$msg"
+
+    msg=`echo "[]" | $EXACL --set --default $DIR1 2>&1`
+    assertEquals 1 $?
+    assertEquals \
+        "File \"$DIR1\": macOS does not support default ACL" \
+        "$msg"
+}
+
 . shunit2


### PR DESCRIPTION
Implement support for default ACL's on Linux, directories only. 

- You can delete a default ACL by setting it to empty. 
- On output, a default ACL entry will have the DEFAULT flag set.
- The DEFAULT flag is ignored on input. Either all entries are default, or none.
