### PR TITLE
Cleanup & Fixes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2020 William W. Fisher
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Rust library for access control lists on `macOS` and `Linux`.
 ## Example
 
 ```rust
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
 use exacl::{getfacl, setfacl, AclEntry, Perm};
 
 // Get the ACL from "./tmp/foo".
@@ -24,32 +23,30 @@ acl.sort();
 
 // Set the ACL for "./tmp/foo".
 setfacl(&["./tmp/foo"], &acl, None)?;
-
-# Ok(()) }
 ```
 
 ## High Level API
 
-This module provides two high level functions, [getfacl] and [setfacl].
+This module provides two high level functions, `getfacl` and `setfacl`.
 
-- [getfacl] retrieves the ACL for a file or directory. On Linux, the
+- `getfacl` retrieves the ACL for a file or directory. On Linux, the
     result includes the entries from the default ACL if there is one.
-- [setfacl] sets the ACL for files or directories, including the default
+- `setfacl` sets the ACL for files or directories, including the default
     ACL on Linux.
 
-Both [getfacl] and [setfacl] work with a vector of [`AclEntry`] structures.
-The structure contains five fields:
+Both `getfacl` and `setfacl` work with a `Vec<AclEntry>`. The
+`AclEntry` structure contains five fields:
 
-- kind : [`AclEntryKind`] - the kind of entry (User, Group, Other, Mask,
+- kind : `AclEntryKind` - the kind of entry (User, Group, Other, Mask,
     or Unknown).
-- name : [`String`] - name of the principal being given access. You can
+- name : `String` - name of the principal being given access. You can
     use a user/group name, decimal uid/gid, or UUID (on macOS).
-- perms : [`Perm`] - permission bits for the entry.
-- flags : [`Flag`] - flags indicating whether an entry is inherited, etc.
-- allow : [`bool`] - true if entry is allowed; false means deny. Linux only
+- perms : `Perm` - permission bits for the entry.
+- flags : `Flag` - flags indicating whether an entry is inherited, etc.
+- allow : `bool` - true if entry is allowed; false means deny. Linux only
     supports allow=true.
 
-[`AclEntry`] supports an ordering that corresponds to ACL canonical order. An
+`AclEntry` supports an ordering that corresponds to ACL canonical order. An
 ACL in canonical order has deny entries first, and inherited entries last.
 On Linux, entries for file-owner sort before named users. You can sort a
 vector of `AclEntry` to put the ACL in canonical order.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,64 @@
-# exacl
+# Exacl
 
-Rust library to manipulate access control lists on macOS and Linux.
+Rust library for access control lists on `macOS` and `Linux`.
 
 ## Example
 
 ```rust
-use exacl::getfacl;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+use exacl::{getfacl, setfacl, AclEntry, Perm};
 
-let acl = getfacl("./tmp/foo", None)?;
+// Get the ACL from "./tmp/foo".
+let mut acl = getfacl("./tmp/foo", None)?;
 
-for entry in acl {
+// Print the contents of the ACL.
+for entry in &acl {
     println!("{:?}", entry);
 }
+
+// Add an ACL entry to the end.
+acl.push(AclEntry::allow_user("some_user", Perm::READ, None));
+
+// Sort the ACL in canonical order.
+acl.sort();
+
+// Set the ACL for "./tmp/foo".
+setfacl(&["./tmp/foo"], &acl, None)?;
+
+# Ok(()) }
 ```
 
-## Set Up Development Environment
+## High Level API
 
-Linux
+This module provides two high level functions, [getfacl] and [setfacl].
 
-```sh
-apt install clang llvm-dev acl libacl1-dev shunit2 shellcheck valgrind
-```
+- [getfacl] retrieves the ACL for a file or directory. On Linux, the
+    result includes the entries from the default ACL if there is one.
+- [setfacl] sets the ACL for files or directories, including the default
+    ACL on Linux.
+
+Both [getfacl] and [setfacl] work with a vector of [`AclEntry`] structures.
+The structure contains five fields:
+
+- kind : [`AclEntryKind`] - the kind of entry (User, Group, Other, Mask,
+    or Unknown).
+- name : [`String`] - name of the principal being given access. You can
+    use a user/group name, decimal uid/gid, or UUID (on macOS).
+- perms : [`Perm`] - permission bits for the entry.
+- flags : [`Flag`] - flags indicating whether an entry is inherited, etc.
+- allow : [`bool`] - true if entry is allowed; false means deny. Linux only
+    supports allow=true.
+
+[`AclEntry`] supports an ordering that corresponds to ACL canonical order. An
+ACL in canonical order has deny entries first, and inherited entries last.
+On Linux, entries for file-owner sort before named users. You can sort a
+vector of `AclEntry` to put the ACL in canonical order.
+
+## Low Level API
+
+The low level API is appropriate if you need finer grained control over
+the ACL.
+
+- Manipulate the access ACL and default ACL independently on Linux.
+- Manipulate the ACL's own flags on macOS.
+- Use the platform specific text formats.

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -90,7 +90,7 @@ impl Acl {
     ///
     /// # Errors
     ///
-    /// Returns an [`io::Error`] on failure.  
+    /// Returns an [`io::Error`] on failure.
     pub fn write<P: AsRef<Path>>(&self, path: P, options: AclOption) -> io::Result<()> {
         let symlink_acl = options.contains(AclOption::SYMLINK_ACL);
         let default_acl = options.contains(AclOption::DEFAULT_ACL);
@@ -118,6 +118,10 @@ impl Acl {
     }
 
     /// Check that ACL meets OS requirements.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`io::Error`] on failure.
     pub fn check(&self) -> io::Result<()> {
         xacl_check(self.acl)
     }
@@ -222,7 +226,6 @@ impl Acl {
             }
         }
 
-        #[cfg(target_os = "linux")]
         if let Some(mask_perms) = Acl::compute_mask_perms(entries, (Flag::empty(), Flag::DEFAULT)) {
             let mask = AclEntry::allow_mask(mask_perms, None);
             if let Err(err) = mask.add_to_acl(&mut access_p) {
@@ -230,7 +233,6 @@ impl Acl {
             }
         }
 
-        #[cfg(target_os = "linux")]
         if let Some(mask_perms) = Acl::compute_mask_perms(entries, (Flag::DEFAULT, Flag::DEFAULT)) {
             let mask = AclEntry::allow_mask(mask_perms, Flag::DEFAULT);
             if let Err(err) = mask.add_to_acl(&mut default_p) {

--- a/src/aclentry.rs
+++ b/src/aclentry.rs
@@ -102,7 +102,7 @@ impl PartialOrd for AclEntry {
 impl AclEntry {
     /// Construct a new access control entry.
     #[must_use]
-    pub fn new(
+    fn new(
         kind: AclEntryKind,
         name: &str,
         perms: Perm,

--- a/src/aclentry.rs
+++ b/src/aclentry.rs
@@ -276,6 +276,7 @@ mod aclentry_tests {
             AclEntry::allow_group("d", Perm::EXECUTE, None),
             AclEntry::allow_user("z", Perm::READ, None),
             AclEntry::allow_group("z", Perm::READ, None),
+            #[cfg(target_os = "macos")]
             AclEntry::deny_user("a", Perm::READ, Flag::FILE_INHERIT),
             AclEntry::deny_user("c", Perm::READ, None),
         ];
@@ -289,6 +290,7 @@ mod aclentry_tests {
             AclEntry::allow_group("3", Perm::EXECUTE, None),
             AclEntry::allow_group("d", Perm::EXECUTE, None),
             AclEntry::allow_group("z", Perm::READ, None),
+            #[cfg(target_os = "macos")]
             AclEntry::deny_user("a", Perm::READ, Flag::FILE_INHERIT),
         ];
 
@@ -308,7 +310,7 @@ mod aclentry_tests {
             AclEntry::allow_other(Perm::EXECUTE, None),
             AclEntry::allow_group("z", Perm::READ, None),
             AclEntry::allow_group("", Perm::READ, None),
-            AclEntry::allow_group("a", Perm::READ, DEFAULT),
+            AclEntry::allow_group("a", Perm::READ, Flag::DEFAULT),
         ];
 
         acl.sort();
@@ -323,7 +325,7 @@ mod aclentry_tests {
             AclEntry::allow_group("z", Perm::READ, None),
             AclEntry::allow_mask(Perm::READ, None),
             AclEntry::allow_other(Perm::EXECUTE, None),
-            AclEntry::allow_group("a", Perm::READ, DEFAULT),
+            AclEntry::allow_group("a", Perm::READ, Flag::DEFAULT),
         ];
 
         assert_eq!(acl, acl_sorted);

--- a/src/bin/exacl.rs
+++ b/src/bin/exacl.rs
@@ -83,9 +83,6 @@ fn set_acl(paths: &[PathBuf], options: AclOption) -> i32 {
         }
     };
 
-    // FIXME(bfish): Preflight the entries here, not inside setfacl?
-    // Should there be a new API: `checkfacl`?
-
     if let Err(err) = setfacl(paths, &entries, options) {
         eprintln!("{}", err);
         return EXIT_FAILURE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,12 +247,27 @@ where
     {
         if options.contains(AclOption::DEFAULT_ACL) {
             let acl = Acl::from_entries(entries).map_err(|err| custom_err("Invalid ACL", &err))?;
+
+            if !acl.is_empty() {
+                acl.check().map_err(|err| custom_err("Invalid ACL", &err))?
+            }
+
             for path in paths {
                 acl.write(path, options)?;
             }
         } else {
             let (access_acl, default_acl) = Acl::from_unified_entries(entries)
                 .map_err(|err| custom_err("Invalid ACL", &err))?;
+
+            access_acl
+                .check()
+                .map_err(|err| custom_err("Invalid ACL", &err))?;
+
+            if !default_acl.is_empty() {
+                default_acl
+                    .check()
+                    .map_err(|err| custom_err("Invalid ACL", &err))?;
+            }
 
             for path in paths {
                 // Try to set default acl first. This will fail if path is not

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,15 +30,15 @@
 //!
 //! ## High Level API
 //!
-//! This module provides two high level functions, [getfacl] and [setfacl].
+//! This module provides two high level functions, [`getfacl`] and [`setfacl`].
 //!
-//! - [getfacl] retrieves the ACL for a file or directory. On Linux, the
+//! - [`getfacl`] retrieves the ACL for a file or directory. On Linux, the
 //!     result includes the entries from the default ACL if there is one.
-//! - [setfacl] sets the ACL for files or directories, including the default
+//! - [`setfacl`] sets the ACL for files or directories, including the default
 //!     ACL on Linux.
 //!
-//! Both [getfacl] and [setfacl] work with a vector of [`AclEntry`] structures.
-//! The structure contains five fields:
+//! Both [`getfacl`] and [`setfacl`] work with a `Vec<AclEntry>`. The
+//! [`AclEntry`] structure contains five fields:
 //!
 //! - kind : [`AclEntryKind`] - the kind of entry (User, Group, Other, Mask,
 //!     or Unknown).

--- a/src/util.rs
+++ b/src/util.rs
@@ -319,7 +319,7 @@ pub(crate) fn xacl_get_file(
         let err = log_err("null", func, &c_path);
 
         // acl_get_file et al. can return NULL (ENOENT) if the file exists, but
-        // there is no ACL. If the path exists, return an *empty* ACL (FIXME).
+        // there is no ACL. If the path exists, return an *empty* ACL.
         if let Some(sg::ENOENT) = err.raw_os_error() {
             if path_exists(&path, symlink_acl) {
                 return xacl_init(1);
@@ -853,11 +853,11 @@ pub(crate) fn xacl_check(acl: acl_t) -> io::Result<()> {
     }
 
     let msg = match ret.try_into().unwrap() {
-        ACL_MULTI_ERROR => "multiple ACL entries with a tag that may occur at most once",
-        ACL_DUPLICATE_ERROR => "multiple ACL entries with the same user/group ID",
-        ACL_MISS_ERROR => "required ACL entry is missing",
-        ACL_ENTRY_ERROR => "invalid ACL entry tag type",
-        _ => "unknown acl_check error message",
+        ACL_MULTI_ERROR => "Multiple ACL entries with a tag that may occur at most once",
+        ACL_DUPLICATE_ERROR => "Multiple ACL entries with the same user/group ID",
+        ACL_MISS_ERROR => "Required ACL entry is missing",
+        ACL_ENTRY_ERROR => "Invalid ACL entry tag type",
+        _ => "Unknown acl_check error message",
     };
 
     fail_custom(msg)

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,7 +1,7 @@
 //! API Tests for exacl module.
 
 use ctor::ctor;
-use exacl::{getfacl, setfacl, Acl, AclEntry, AclOption, Flag, Perm};
+use exacl::{getfacl, Acl, AclEntry, AclOption, Flag, Perm};
 use log::debug;
 use std::io;
 
@@ -378,6 +378,8 @@ fn test_from_unified_entries() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_too_many_entries() -> io::Result<()> {
+    use exacl::setfacl;
+
     // This test depends on the type of file system. With ext* systems, we
     // expect ACL's with 508 entries to fail.
     let mut entries = vec![
@@ -397,10 +399,10 @@ fn test_too_many_entries() -> io::Result<()> {
     setfacl(&files, &entries, None)?;
     debug!("{} entries is okay", entries.len());
 
+    // Add 508th entry.
     entries.push(AclEntry::allow_user("1500", Perm::READ, None));
-    debug!("{} entries fails", entries.len());
 
-    // 508 entries is one too many.
+    // 508th entry is one too many.
     let err = setfacl(&files, &entries, None).err().unwrap();
     assert!(err.to_string().contains("No space left on device"));
 

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -470,6 +470,16 @@ testWriteUnifiedAclToFile1() {
         "${msg//\"/}"
 }
 
+testWriteUnifiedAclToMissingFile() {
+    # Set ACL with required entries.
+    input=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[read,write],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true},{kind:user,name:,perms:[read,write],flags:[default],allow:true},{kind:group,name:,perms:[read,write],flags:[default],allow:true},{kind:other,name:,perms:[],flags:[default],allow:true}]")
+    msg=$(echo "$input" | $EXACL --set $DIR/non_existant 2>&1)
+    assertEquals "set unified acl" 1 $?
+    assertEquals \
+        "File \"$DIR/non_existant\": No such file or directory (os error 2)" \
+        "$msg"
+}
+
 testWriteUnifiedAclToDir1() {
     # Set ACL with required entries.
     input=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[read,write],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true},{kind:user,name:,perms:[read,write],flags:[default],allow:true},{kind:group,name:,perms:[read,write],flags:[default],allow:true},{kind:other,name:,perms:[],flags:[default],allow:true}]")

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -167,7 +167,7 @@ testWriteAclToMissingFile() {
     msg=$(echo "$input" | $EXACL --set $DIR/non_existant 2>&1)
     assertEquals 1 $?
     assertEquals \
-        "File \"$DIR/non_existant\": required ACL entry is missing" \
+        "Invalid ACL: Required ACL entry is missing" \
         "$msg"
 
     input=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
@@ -184,7 +184,7 @@ testWriteAclToFile1() {
     msg=$(echo "$input" | $EXACL --set $FILE1 2>&1)
     assertEquals "set acl to empty" 1 $?
     assertEquals \
-        "File \"$FILE1\": required ACL entry is missing" \
+        "Invalid ACL: Required ACL entry is missing" \
         "$msg"
 
     # Verify ACL.
@@ -211,7 +211,7 @@ testWriteAclToFile1() {
     msg=$(echo "$input" | $EXACL --set $FILE1 2>&1)
     assertEquals "check required entry" 1 $?
     assertEquals \
-        "File \"$FILE1\": required ACL entry is missing" \
+        "Invalid ACL: Required ACL entry is missing" \
         "$msg"
 
     # Set ACL for current user specifically, with required entries.
@@ -247,7 +247,7 @@ testWriteAclToDir1() {
     msg=$(echo "$input" | $EXACL --set $DIR1 2>&1)
     assertEquals 1 $?
     assertEquals \
-        "File \"$DIR1\": required ACL entry is missing" \
+        "Invalid ACL: Required ACL entry is missing" \
         "$msg"
 
     # Verify directory ACL.
@@ -327,7 +327,7 @@ testWriteAclToLink1() {
     msg=$(echo "$input" | $EXACL --set $LINK1 2>&1)
     assertEquals 1 $?
     assertEquals \
-        "File \"$LINK1\": required ACL entry is missing" \
+        "Invalid ACL: Required ACL entry is missing" \
         "$msg"
 
     input=$(quotifyJson "[{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:user,name:$ME,perms:[read],flags:[],allow:true},{kind:user,name:,perms:[read,write,execute],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
@@ -515,7 +515,7 @@ testSetDefault() {
     msg=$(echo "$input" | $EXACL --set --default $DIR1 2>&1)
     assertEquals "set default acl" 1 $?
     assertEquals \
-        "File \"$DIR1\": multiple ACL entries with a tag that may occur at most once" \
+        "Invalid ACL: Multiple ACL entries with a tag that may occur at most once" \
         "$msg"
 
     # Check ACL is updated.
@@ -546,7 +546,7 @@ testMissingFlags() {
     msg=$(echo "$input" | $EXACL --set non_existant 2>&1)
     assertEquals 1 $?
     assertEquals \
-        'File "non_existant": required ACL entry is missing' \
+        'Invalid ACL: Required ACL entry is missing' \
         "${msg//\`/}"
 }
 
@@ -555,7 +555,7 @@ testMissingAllow() {
     msg=$(echo "$input" | $EXACL --set non_existant 2>&1)
     assertEquals 1 $?
     assertEquals \
-        'File "non_existant": required ACL entry is missing' \
+        'Invalid ACL: Required ACL entry is missing' \
         "${msg//\`/}"
 }
 


### PR DESCRIPTION
- Fix sorting order when flags are present.
- Improve error reporting for invalid ACL's.
- Add MIT license.
- Clean up documentation.