### PR TITLE
Add ACCESS_ACL option.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Update Rust Toolchain
+      run: rustup update
     - name: Install dependencies (macOS)
       run: brew install shunit2 shellcheck shfmt
       if: runner.os == 'macOS'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,6 @@ clap = "2.33.3"
 env_logger = "0.8.2"
 structopt = "0.3.20"
 serde_json = "1.0.59"
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Exacl &emsp; [![CRATE]][crates] [![CI]][actions] [![API]][docs]
+# Exacl &emsp; [![CRATE]][crates] [![CI]][actions] [![API]][docs] [![BUILD]][cirrus]
 
 [CRATE]: https://img.shields.io/crates/v/exacl
 [crates]: https://crates.io/crates/exacl
@@ -6,6 +6,8 @@
 [actions]: https://github.com/byllyfish/exacl/actions?query=branch%3Amain
 [API]: https://docs.rs/exacl/badge.svg
 [docs]: https://docs.rs/exacl
+[BUILD]: https://api.cirrus-ci.com/github/byllyfish/exacl.svg
+[cirrus]: https://cirrus-ci.com/github/byllyfish/exacl
 
 Rust library to manipulate file system access control lists (ACL) on `macOS`, `Linux`, and `FreeBSD`.
 

--- a/examples/exacl.rs
+++ b/examples/exacl.rs
@@ -26,6 +26,10 @@ struct Opt {
     #[structopt(long)]
     set: bool,
 
+    /// Get or set the access ACL.
+    #[structopt(short = "a", long)]
+    access: bool,
+
     /// Get or set the default ACL.
     #[structopt(short = "d", long)]
     default: bool,
@@ -60,6 +64,9 @@ fn main() {
     let opt = Opt::from_args();
 
     let mut options = AclOption::empty();
+    if opt.access {
+        options |= AclOption::ACCESS_ACL;
+    }
     if opt.default {
         options |= AclOption::DEFAULT_ACL;
     }

--- a/examples/exacl.rs
+++ b/examples/exacl.rs
@@ -21,6 +21,7 @@ use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(name = "exacl", about = "Read or write a file's ACL.")]
+#[allow(clippy::struct_excessive_bools)]
 struct Opt {
     /// Set file's ACL.
     #[structopt(long)]

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -18,15 +18,18 @@ bitflags! {
     /// Controls how ACL's are accessed.
     #[derive(Default)]
     pub struct AclOption : u32 {
-        /// Get/set the ACL of the symlink itself (macOS only).
-        const SYMLINK_ACL = 0x01;
+        /// Get/set the access ACL only (Linux and FreeBSD only).
+        const ACCESS_ACL = 0b0001;
 
         /// Get/set the default ACL only (Linux and FreeBSD only).
-        const DEFAULT_ACL = 0x02;
+        const DEFAULT_ACL = 0b0010;
+
+        /// Get/set the ACL of the symlink itself (macOS only).
+        const SYMLINK_ACL = 0b0100;
 
         /// Ignore expected error when using DEFAULT_ACL on a file.
         #[doc(hidden)]
-        const IGNORE_EXPECTED_FILE_ERR = 0x10;
+        const IGNORE_EXPECTED_FILE_ERR = 0b10000;
     }
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::io;
 
 /// Write value of a simple enum as a `serde` serialized string.
-pub fn write_enum<'a, 'b, T: Serialize>(f: &'a mut fmt::Formatter<'b>, value: &T) -> fmt::Result {
+pub fn write_enum<T: Serialize>(f: &mut fmt::Formatter, value: &T) -> fmt::Result {
     let mut serializer = EnumSerializer(f);
     value
         .serialize(&mut serializer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,9 @@ fn _getfacl(path: &Path, options: AclOption) -> io::Result<Vec<AclEntry>> {
 
 #[cfg(not(target_os = "macos"))]
 fn _getfacl(path: &Path, options: AclOption) -> io::Result<Vec<AclEntry>> {
-    if options.contains(AclOption::DEFAULT_ACL) {
+    if options.contains(AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL) {
+        fail_custom("ACCESS_ACL and DEFAULT_ACL are mutually exclusive options")
+    } else if options.intersects(AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL) {
         Acl::read(path, options)?.entries()
     } else {
         let mut entries = Acl::read(path, options)?.entries()?;
@@ -253,7 +255,9 @@ fn _setfacl<P>(paths: &[P], entries: &[AclEntry], options: AclOption) -> io::Res
 where
     P: AsRef<Path>,
 {
-    if options.contains(AclOption::DEFAULT_ACL) {
+    if options.contains(AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL) {
+        fail_custom("ACCESS_ACL and DEFAULT_ACL are mutually exclusive options")?;
+    } else if options.intersects(AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL) {
         let acl = Acl::from_entries(entries).map_err(|err| custom_err("Invalid ACL", &err))?;
 
         for path in paths {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! - [`getfacl`] retrieves the ACL for a file or directory.
 //! - [`setfacl`] sets the ACL for files or directories.
 //!
-//! On Linux and FreeBSD, the ACL contains entries for the default ACL, if
+//! On Linux and `FreeBSD`, the ACL contains entries for the default ACL, if
 //! present.
 //!
 //! Both [`getfacl`] and [`setfacl`] work with a `Vec<AclEntry>`. The

--- a/src/util.rs
+++ b/src/util.rs
@@ -381,7 +381,7 @@ pub fn xacl_get_perm(entry: acl_entry_t) -> io::Result<Perm> {
     let mut perms = Perm::empty();
     for perm in BitIter(Perm::all()) {
         let res = unsafe { acl_get_perm(permset, perm.bits()) };
-        debug_assert!(res >= 0 && res <= 1);
+        debug_assert!((0..=1).contains(&res));
         if res == 1 {
             perms |= perm;
         }
@@ -406,7 +406,7 @@ fn xacl_get_flags_np(obj: *mut c_void) -> io::Result<Flag> {
     let mut flags = Flag::empty();
     for flag in BitIter(Flag::all()) {
         let res = unsafe { acl_get_flag_np(flagset, flag.bits()) };
-        debug_assert!(res >= 0 && res <= 1);
+        debug_assert!((0..=1).contains(&res));
         if res == 1 {
             flags |= flag;
         }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -495,7 +495,7 @@ allow::user:ccc:read,execute
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn test_exclusive_acloptions() {
     let path = "/tmp";
 
@@ -509,5 +509,23 @@ fn test_exclusive_acloptions() {
     assert_eq!(
         err2.to_string(),
         "ACCESS_ACL and DEFAULT_ACL are mutually exclusive options"
+    );
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn test_exclusive_acloptions() {
+    let path = "/tmp";
+
+    let err1 = getfacl(&path, AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL).unwrap_err();
+    assert_eq!(
+        err1.to_string(),
+        "File \"/tmp\": macOS does not support default ACL"
+    );
+
+    let err2 = setfacl(&[path], &[], AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL).unwrap_err();
+    assert_eq!(
+        err2.to_string(),
+        "File \"/tmp\": macOS does not support default ACL"
     );
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,7 +1,7 @@
 //! API Tests for exacl module.
 
 use ctor::ctor;
-use exacl::{getfacl, Acl, AclEntry, AclOption, Flag, Perm};
+use exacl::{getfacl, setfacl, Acl, AclEntry, AclOption, Flag, Perm};
 use log::debug;
 use std::io;
 
@@ -492,4 +492,22 @@ allow::user:ccc:read,execute
     assert_eq!(expected, actual);
 
     Ok(())
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_exclusive_acloptions() {
+    let path = "/tmp";
+
+    let err1 = getfacl(&path, AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL).unwrap_err();
+    assert_eq!(
+        err1.to_string(),
+        "ACCESS_ACL and DEFAULT_ACL are mutually exclusive options"
+    );
+
+    let err2 = setfacl(&[path], &[], AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL).unwrap_err();
+    assert_eq!(
+        err2.to_string(),
+        "ACCESS_ACL and DEFAULT_ACL are mutually exclusive options"
+    );
 }

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -516,6 +516,30 @@ default:other::---" \
         "${msg}"
 }
 
+testWriteAccessAclToDir1() {
+    # Check access ACL.
+    msg=$($EXACL --access $DIR1)
+    assertEquals "check acl" 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[read,write],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set access ACL.
+    input=$(quotifyJson "[{kind:user,name:,perms:[execute],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
+    msg=$(echo "$input" | $EXACL --set --access $DIR1 2>&1)
+    assertEquals "set access acl" 0 $?
+    assertEquals \
+        "" \
+        "$msg"
+
+    # Check access ACL is updated, and default ACL is unchanged.
+    msg=$($EXACL $DIR1)
+    assertEquals "check acl again" 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[execute],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true},{kind:user,name:,perms:[read,write],flags:[default],allow:true},{kind:group,name:,perms:[read,write],flags:[default],allow:true},{kind:other,name:,perms:[],flags:[default],allow:true}]" \
+        "${msg//\"/}"
+}
+
 testSetDefault() {
     # Set ACL with both access and default entries.
     input=$(quotifyJson "[{kind:user,name:,perms:[execute],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[execute],flags:[],allow:true},{kind:user,name:,perms:[read,write],flags:[default],allow:true},{kind:group,name:,perms:[read,write],flags:[default],allow:true},{kind:other,name:,perms:[],flags:[default],allow:true}]")
@@ -525,11 +549,19 @@ testSetDefault() {
         'Invalid ACL: entry 3: duplicate default entry for "user"' \
         "$msg"
 
-    # Check ACL is updated.
+    # Set ACL with default entries.
+    input=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[default],allow:true},{kind:group,name:,perms:[read,write],flags:[default],allow:true},{kind:other,name:,perms:[],flags:[default],allow:true}]")
+    msg=$(echo "$input" | $EXACL --set --default $DIR1 2>&1)
+    assertEquals 0 $?
+    assertEquals \
+        '' \
+        "$msg"
+
+    # Check ACL.
     msg=$($EXACL $DIR1)
     assertEquals "check acl again" 0 $?
     assertEquals \
-        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[read,write],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true},{kind:user,name:,perms:[read,write],flags:[default],allow:true},{kind:group,name:,perms:[read,write],flags:[default],allow:true},{kind:other,name:,perms:[],flags:[default],allow:true}]" \
+        "[{kind:user,name:,perms:[execute],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true},{kind:user,name:,perms:[read,write],flags:[default],allow:true},{kind:group,name:,perms:[read,write],flags:[default],allow:true},{kind:other,name:,perms:[],flags:[default],allow:true}]" \
         "${msg//\"/}"
 
     # Remove the default ACL.
@@ -544,7 +576,7 @@ testSetDefault() {
     msg=$($EXACL $DIR1)
     assertEquals "check acl again" 0 $?
     assertEquals \
-        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[read,write],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "[{kind:user,name:,perms:[execute],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
         "${msg//\"/}"
 }
 


### PR DESCRIPTION
- Fix docs.rs metadata to build docs correctly.
- Allow for '-' in permission abbreviation.
- Clippy lint fixes.