### PR TITLE
Remove the num_enum dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ buildtime_bindgen = ["bindgen"]
 [dependencies]
 bitflags = "1.2.1"
 log = "0.4.11"
-num_enum = "0.5.1"
 uuid = "0.8.1"
 scopeguard = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -5,7 +5,6 @@ use crate::format;
 use crate::sys::*;
 
 use bitflags::bitflags;
-use num_enum::TryFromPrimitive;
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;
 
@@ -76,7 +75,7 @@ impl BitIterable for Flag {
     }
 }
 
-#[derive(Deserialize, Serialize, TryFromPrimitive, Copy, Clone, Debug)]
+#[derive(Deserialize, Serialize, Copy, Clone, Debug)]
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 enum FlagName {
@@ -101,7 +100,27 @@ enum FlagName {
 
 impl FlagName {
     fn from_flag(flag: Flag) -> Option<FlagName> {
-        FlagName::try_from(flag.bits as u32).ok()
+        match flag {
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Flag::INHERITED => Some(FlagName::inherited),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Flag::FILE_INHERIT => Some(FlagName::file_inherit),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Flag::DIRECTORY_INHERIT => Some(FlagName::directory_inherit),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Flag::LIMIT_INHERIT => Some(FlagName::limit_inherit),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Flag::ONLY_INHERIT => Some(FlagName::only_inherit),
+
+            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+            Flag::DEFAULT => Some(FlagName::default),
+
+            _ => None,
+        }
     }
 
     const fn to_flag(self) -> Flag {

--- a/src/perm.rs
+++ b/src/perm.rs
@@ -5,7 +5,6 @@ use crate::format;
 use crate::sys::*;
 
 use bitflags::bitflags;
-use num_enum::TryFromPrimitive;
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;
 
@@ -152,7 +151,7 @@ impl BitIterable for Perm {
     }
 }
 
-#[derive(Deserialize, Serialize, TryFromPrimitive, Copy, Clone, Debug)]
+#[derive(Deserialize, Serialize, Copy, Clone, Debug)]
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 enum PermName {
@@ -204,7 +203,54 @@ enum PermName {
 
 impl PermName {
     fn from_perm(perm: Perm) -> Option<PermName> {
-        PermName::try_from(perm.bits).ok()
+        match perm {
+            Perm::READ => Some(PermName::read),
+
+            Perm::WRITE => Some(PermName::write),
+
+            Perm::EXECUTE => Some(PermName::execute),
+
+            #[cfg(target_os = "freebsd")]
+            Perm::READ_DATA => Some(PermName::read_data),
+
+            #[cfg(target_os = "freebsd")]
+            Perm::WRITE_DATA => Some(PermName::write_data),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::DELETE => Some(PermName::delete),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::APPEND => Some(PermName::append),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::DELETE_CHILD => Some(PermName::delete_child),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::READATTR => Some(PermName::readattr),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::WRITEATTR => Some(PermName::writeattr),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::READEXTATTR => Some(PermName::readextattr),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::WRITEEXTATTR => Some(PermName::writeextattr),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::READSECURITY => Some(PermName::readsecurity),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::WRITESECURITY => Some(PermName::writesecurity),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::CHOWN => Some(PermName::chown),
+
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            Perm::SYNC => Some(PermName::sync),
+
+            _ => None,
+        }
     }
 
     const fn to_perm(self) -> Perm {


### PR DESCRIPTION
This improves compile times by ~30% by removing a transitive dependency on proc-macro-crate, thiserror and toml. While this duplicates a bit of code, I think it is worth the significant compile time improvement.

<details><summary>Before</summary>

![image](https://user-images.githubusercontent.com/17426603/151667630-3c6920e5-9ab1-4b10-9fa0-95e7dbe6244c.png)

</details>

<details><summary>After</summary>

![image](https://user-images.githubusercontent.com/17426603/151667644-7ff54379-640f-4225-b1c1-3eb924e86206.png)

</details>

<details><summary><code>Cargo.lock</code> diff</summary>

```diff
diff --git a/Cargo.lock b/Cargo.lock
index b9b2300..1fb576e 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,6 @@ dependencies = [
  "ctor",
  "env_logger",
  "log",
- "num_enum",
  "scopeguard",
  "serde",
  "serde_json",
@@ -263,43 +262,12 @@ dependencies = [
  "version_check",
 ]
 
-[[package]]
-name = "num_enum"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720d3ea1055e4e4574c0c0b0f8c3fd4f24c4cdaf465948206dea090b57b526ad"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d992b768490d7fe0d8586d9b5745f6c49f557da6d81dc982b1d167ad4edbb21"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
 [[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
-[[package]]
-name = "proc-macro-crate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
-dependencies = [
- "thiserror",
- "toml",
-]
-
 [[package]]
 name = "proc-macro-error"
 version = "1.0.4"
@@ -505,35 +473,6 @@ dependencies = [
  "unicode-width",
 ]
 
-[[package]]
-name = "thiserror"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
-]
-
 [[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
```

</summary>