### PR TITLE
Add build script to link to static libacl and correct tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 Cargo.lock
 .DS_Store
 /.vscode
-libs/usr

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 .DS_Store
 /.vscode
+libs/usr

--- a/build.rs
+++ b/build.rs
@@ -13,36 +13,31 @@ https://github.com/byllyfish/exacl/issues
 "#;
 
 fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
     #[cfg(target_os = "linux")]
     {
         // Tell cargo to tell rustc to build libacl and link to libacl.a, only on Linux.
         let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
         let libs_path = Path::new(manifest_dir.as_str()).join("libs");
-        if !libs_path.exists() {
-            panic!("Missing libs path")
-        }
-        if !libs_path.join("usr").exists() {
+        assert!(libs_path.exists(), "Missing libs path");
+        if !Path::new(out_dir.as_str()).join("usr").exists() {
             let exit = std::process::Command::new("./build.sh")
+                .arg(out_dir.as_str())
                 .current_dir(libs_path.as_path())
                 .spawn()
                 .expect("Command is valid")
                 .wait()
                 .expect("Script did not fail");
-            if !exit.success() {
-                panic!("Build command failed with {:?}", exit.code())
-            }
+            assert!(exit.success(), "Build command failed with {:?}", exit.code());
         }
-        println!("cargo:rustc-link-search={}/usr/lib", libs_path.to_string_lossy());
+        println!("cargo:rustc-link-search={}/usr/lib", out_dir.as_str());
         println!("cargo:rustc-link-lib=static=acl");
     }
-
-
-    let out_dir = env::var("OUT_DIR").unwrap();
     let out_path = Path::new(&out_dir).join("bindings.rs");
     let wrapper = "bindgen/wrapper.h";
 
     // Tell cargo to invalidate the built crate whenever the wrapper changes
-    println!("cargo:rerun-if-changed={}", wrapper);
+    println!("cargo:rerun-if-changed={wrapper}");
 
     #[cfg(feature = "buildtime_bindgen")]
     bindgen_bindings(wrapper, &out_path);
@@ -64,6 +59,11 @@ fn bindgen_bindings(wrapper: &str, out_path: &Path) {
     if cfg!(target_os = "macos") {
         // Pass output of `xcrun --sdk macosx --show-sdk-path`.
         builder = builder.clang_arg("-isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk");
+    }
+
+    if cfg!(target_os = "linux") {
+        let out_dir = env::var("OUT_DIR").unwrap();
+        builder = builder.clang_arg(format!("-I{}/usr/include", out_dir));
     }
 
     // Specify the types, functions, and constants we want to include.
@@ -129,7 +129,7 @@ fn prebuilt_bindings(out_path: &Path) {
         s => panic!("Unsupported target OS: {}", s),
     };
 
-    let bindings_path = format!("bindgen/bindings_{}.rs", target);
+    let bindings_path = format!("bindgen/bindings_{target}.rs");
     if let Err(err) = std::fs::copy(&bindings_path, out_path) {
         panic!("Can't copy {:?} to {:?}: {}", bindings_path, out_path, err);
     }

--- a/build.rs
+++ b/build.rs
@@ -13,13 +13,33 @@ https://github.com/byllyfish/exacl/issues
 "#;
 
 fn main() {
+    #[cfg(target_os = "linux")]
+    {
+        // Tell cargo to tell rustc to build libacl and link to libacl.a, only on Linux.
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let libs_path = Path::new(manifest_dir.as_str()).join("libs");
+        if !libs_path.exists() {
+            panic!("Missing libs path")
+        }
+        if !libs_path.join("usr").exists() {
+            let exit = std::process::Command::new("./build.sh")
+                .current_dir(libs_path.as_path())
+                .spawn()
+                .expect("Command is valid")
+                .wait()
+                .expect("Script did not fail");
+            if !exit.success() {
+                panic!("Build command failed with {:?}", exit.code())
+            }
+        }
+        println!("cargo:rustc-link-search={}/usr/lib", libs_path.to_string_lossy());
+        println!("cargo:rustc-link-lib=static=acl");
+    }
+
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_path = Path::new(&out_dir).join("bindings.rs");
     let wrapper = "bindgen/wrapper.h";
-
-    // Tell cargo to tell rustc to link libacl.so, only on Linux.
-    #[cfg(target_os = "linux")]
-    println!("cargo:rustc-link-lib=acl");
 
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed={}", wrapper);
@@ -56,13 +76,13 @@ fn bindgen_bindings(wrapper: &str, out_path: &Path) {
         "mbr_gid_to_uuid",
         "mbr_uuid_to_id",
         #[cfg(target_os = "macos")]
-        "open",
+            "open",
         #[cfg(target_os = "macos")]
-        "close",
+            "close",
         #[cfg(target_os = "freebsd")]
-        "pathconf",
+            "pathconf",
         #[cfg(target_os = "freebsd")]
-        "lpathconf",
+            "lpathconf",
     ];
     let vars = [
         "ACL_.*",
@@ -73,7 +93,7 @@ fn bindgen_bindings(wrapper: &str, out_path: &Path) {
         "ENOMEM",
         "ERANGE",
         #[cfg(target_os = "macos")]
-        "O_SYMLINK",
+            "O_SYMLINK",
         "ID_TYPE_UID",
         "ID_TYPE_GID",
     ];

--- a/libs/build.sh
+++ b/libs/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eux
+
+# Remove old builds
+rm -rf acl
+
+# Clone the repo and switch to latest version
+git clone https://git.savannah.nongnu.org/git/acl.git
+cd acl || exit 1
+git checkout tags/v2.3.1
+
+# Generate the library (static and pie/pic included)
+./autogen.sh
+./configure --enable-static --with-pic --prefix "$(pwd)/usr"
+make
+make install
+
+# Exit and remove artefacts
+cd .. || exit 1
+cp -r acl/usr .
+rm -rf acl

--- a/libs/build.sh
+++ b/libs/build.sh
@@ -3,6 +3,8 @@
 set -eux
 
 # Remove old builds
+cd "$1" || exit 1
+
 rm -rf acl
 
 # Clone the repo and switch to latest version

--- a/src/qualifier.rs
+++ b/src/qualifier.rs
@@ -196,6 +196,8 @@ impl fmt::Display for Qualifier {
 
 #[cfg(test)]
 mod qualifier_tests {
+    use std::ffi::CString;
+    use std::str::FromStr;
     use super::*;
 
     #[test]
@@ -231,8 +233,14 @@ mod qualifier_tests {
 
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         {
+            let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
+            let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
+            let s = s.split(":").collect::<Vec<_>>();
+            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let user_id = u32::from_str(s.get(2).expect("uid is there")).expect("UIDs are valid u32");
+
             let user = Qualifier::user_named("daemon").ok();
-            assert_eq!(user, Some(Qualifier::User(1)));
+            assert_eq!(user, Some(Qualifier::User(user_id)));
         }
     }
 
@@ -252,8 +260,14 @@ mod qualifier_tests {
 
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         {
+            let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
+            let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
+            let s = s.split(":").collect::<Vec<_>>();
+            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let group_id = u32::from_str(s.get(3).expect("gid is there")).expect("GIDs are valid u32");
+
             let group = Qualifier::group_named("daemon").ok();
-            assert_eq!(group, Some(Qualifier::Group(1)));
+            assert_eq!(group, Some(Qualifier::Group(group_id)));
         }
     }
 }

--- a/src/qualifier.rs
+++ b/src/qualifier.rs
@@ -235,8 +235,8 @@ mod qualifier_tests {
         {
             let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
             let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
-            let s = s.split(":").collect::<Vec<_>>();
-            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let s = s.split(':').collect::<Vec<_>>();
+            assert_eq!(s.first().unwrap(), &"daemon");
             let user_id = u32::from_str(s.get(2).expect("uid is there")).expect("UIDs are valid u32");
 
             let user = Qualifier::user_named("daemon").ok();
@@ -262,8 +262,8 @@ mod qualifier_tests {
         {
             let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
             let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
-            let s = s.split(":").collect::<Vec<_>>();
-            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let s = s.split(':').collect::<Vec<_>>();
+            assert_eq!(s.first().unwrap(), &"daemon");
             let group_id = u32::from_str(s.get(3).expect("gid is there")).expect("GIDs are valid u32");
 
             let group = Qualifier::group_named("daemon").ok();

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -277,8 +277,8 @@ mod unix_tests {
         {
             let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
             let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
-            let s = s.split(":").collect::<Vec<_>>();
-            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let s = s.split(':').collect::<Vec<_>>();
+            assert_eq!(s.first().unwrap(), &"daemon");
             let user_id:u32 = std::str::FromStr::from_str(s.get(2).expect("uid is there")).expect("UIDs are valid u32");
 
             assert_eq!(name_to_uid("daemon").ok(), Some(user_id));
@@ -302,8 +302,8 @@ mod unix_tests {
         {
             let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
             let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
-            let s = s.split(":").collect::<Vec<_>>();
-            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let s = s.split(':').collect::<Vec<_>>();
+            assert_eq!(s.first().unwrap(), &"daemon");
             let group_id:u32 = std::str::FromStr::from_str(s.get(3).expect("gid is there")).expect("GIDs are valid u32");
 
             assert_eq!(name_to_gid("daemon").ok(), Some(group_id));
@@ -321,8 +321,8 @@ mod unix_tests {
         {
             let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
             let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
-            let s = s.split(":").collect::<Vec<_>>();
-            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let s = s.split(':').collect::<Vec<_>>();
+            assert_eq!(s.first().unwrap(), &"daemon");
             let user_id:u32 = std::str::FromStr::from_str(s.get(2).expect("uid is there")).expect("UIDs are valid u32");
 
             assert_eq!(uid_to_name(user_id).unwrap(), "daemon");
@@ -340,8 +340,8 @@ mod unix_tests {
         {
             let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
             let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
-            let s = s.split(":").collect::<Vec<_>>();
-            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let s = s.split(':').collect::<Vec<_>>();
+            assert_eq!(s.first().unwrap(), &"daemon");
             let group_id:u32 = std::str::FromStr::from_str(s.get(3).expect("gid is there")).expect("GIDs are valid u32");
 
             assert_eq!(gid_to_name(group_id).unwrap(), "daemon");

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -274,7 +274,15 @@ mod unix_tests {
         assert_eq!(name_to_uid("_spotlight").ok(), Some(89));
 
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        assert_eq!(name_to_uid("daemon").ok(), Some(1));
+        {
+            let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
+            let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
+            let s = s.split(":").collect::<Vec<_>>();
+            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let user_id:u32 = std::str::FromStr::from_str(s.get(2).expect("uid is there")).expect("UIDs are valid u32");
+
+            assert_eq!(name_to_uid("daemon").ok(), Some(user_id));
+        }
     }
 
     #[test]
@@ -291,7 +299,15 @@ mod unix_tests {
         assert_eq!(name_to_gid("_spotlight").ok(), Some(89));
 
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        assert_eq!(name_to_gid("daemon").ok(), Some(1));
+        {
+            let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
+            let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
+            let s = s.split(":").collect::<Vec<_>>();
+            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let group_id:u32 = std::str::FromStr::from_str(s.get(3).expect("gid is there")).expect("GIDs are valid u32");
+
+            assert_eq!(name_to_gid("daemon").ok(), Some(group_id));
+        }
     }
 
     #[test]
@@ -302,7 +318,15 @@ mod unix_tests {
         assert_eq!(uid_to_name(89).unwrap(), "_spotlight");
 
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        assert_eq!(uid_to_name(1).unwrap(), "daemon");
+        {
+            let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
+            let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
+            let s = s.split(":").collect::<Vec<_>>();
+            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let user_id:u32 = std::str::FromStr::from_str(s.get(2).expect("uid is there")).expect("UIDs are valid u32");
+
+            assert_eq!(uid_to_name(user_id).unwrap(), "daemon");
+        }
     }
 
     #[test]
@@ -313,7 +337,15 @@ mod unix_tests {
         assert_eq!(gid_to_name(89).unwrap(), "_spotlight");
 
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        assert_eq!(gid_to_name(1).unwrap(), "daemon");
+        {
+            let daemon = std::process::Command::new("getent").arg("passwd").arg("daemon").output().expect("Valid Unix command");
+            let s = unsafe { CString::from_vec_unchecked(daemon.stdout) }.into_string().expect("Valid utf8");
+            let s = s.split(":").collect::<Vec<_>>();
+            assert_eq!(s.get(0).unwrap(), &"daemon");
+            let group_id:u32 = std::str::FromStr::from_str(s.get(3).expect("gid is there")).expect("GIDs are valid u32");
+
+            assert_eq!(gid_to_name(group_id).unwrap(), "daemon");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Hello,
This PR adds a new build script part specific to linux to statically link to a PIE libacl.a generated automatically with a build.sh scripts, this is in no way how a sys crate would be made but it was the easiest compared to the complexity of the libacl project.
I also corrected tests to work with other distro (daemon is not uid:1 gid:1 on every platform and for xfs, tmpfs... it's not the same limit as ext
I do not hope that you merge this as it is as using a build.sh script like so is pretty error prone and linking to a static library might not be what all users want but you could take some of those insights and use them.

I will try to make a proper libacl sys crate that build the project with cc if I have the time, in the meantime that's the easiest path.