### PR TITLE
Support FreeBSD 14 in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,12 +5,12 @@ task:
   name: CI / build (freebsd)
 
   matrix:
-    - name: CI / build (freebsd-13.1)
+    - name: CI / build (freebsd-13.2)
       freebsd_instance:
-        image_family: freebsd-13-1
-    - name: CI / build (freebsd-12.2)
+        image_family: freebsd-13-2
+    - name: CI / build (freebsd-14.0)
       freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-14-0
 
   sysinfo_script:
     # Record info about the test environment.

--- a/bindgen/bindings_freebsd14.diff
+++ b/bindgen/bindings_freebsd14.diff
@@ -1,0 +1,29 @@
+69d68
+< pub type __uint16_t = ::std::os::raw::c_ushort;
+74d72
+< pub type __mode_t = __uint16_t;
+77d74
+< pub type mode_t = __mode_t;
+105,107d101
+<     pub fn acl_cmp_np(_acl1: acl_t, _acl2: acl_t) -> ::std::os::raw::c_int;
+< }
+< extern "C" {
+173,186d166
+<     pub fn acl_equiv_mode_np(_acl: acl_t, _mode_p: *mut mode_t) -> ::std::os::raw::c_int;
+< }
+< extern "C" {
+<     pub fn acl_extended_file_np(_path_p: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+< }
+< extern "C" {
+<     pub fn acl_extended_file_nofollow_np(
+<         _path_p: *const ::std::os::raw::c_char,
+<     ) -> ::std::os::raw::c_int;
+< }
+< extern "C" {
+<     pub fn acl_extended_link_np(_path_p: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+< }
+< extern "C" {
+188,190d167
+< }
+< extern "C" {
+<     pub fn acl_from_mode_np(_mode: mode_t) -> acl_t;

--- a/ci/bindgen.sh
+++ b/ci/bindgen.sh
@@ -33,7 +33,6 @@ bindings=$(find ./target/debug/build -name "bindings.rs")
 echo "Comparing $bindings and $prebuilt_bindings"
 
 diff_out="$(mktemp)"
-echo "$diff_out"
 trap '{ rm -f -- "$diff_out"; }' EXIT
 
 if diff "$bindings" "$prebuilt_bindings" >"$diff_out"; then

--- a/ci/bindgen.sh
+++ b/ci/bindgen.sh
@@ -36,7 +36,7 @@ diff_out="$(mktemp)"
 echo "$diff_out"
 trap '{ rm -f -- "$diff_out"; }' EXIT
 
-if diff "$bindings" "$prebuilt_bindings" > "$diff_out"; then
+if diff "$bindings" "$prebuilt_bindings" >"$diff_out"; then
     echo "Success."
     rm "$diff_out"
     exit 0

--- a/ci/bindgen.sh
+++ b/ci/bindgen.sh
@@ -31,6 +31,30 @@ prebuilt_bindings="./bindgen/bindings_$target.rs"
 bindings=$(find ./target/debug/build -name "bindings.rs")
 
 echo "Comparing $bindings and $prebuilt_bindings"
-diff "$bindings" "$prebuilt_bindings"
 
-exit 0
+diff_out="$(mktemp)"
+echo "$diff_out"
+trap '{ rm -f -- "$diff_out"; }' EXIT
+
+if diff "$bindings" "$prebuilt_bindings" > "$diff_out"; then
+    echo "Success."
+    rm "$diff_out"
+    exit 0
+fi
+
+echo "Differences exist."
+
+# FreeBSD 14 includes several additional ACL API's that are not used.
+# Check the diff output against the approved diff output.
+freebsd_diff="./bindgen/bindings_freebsd14.diff"
+
+if [ "$target" = "freebsd" ]; then
+    echo "Comparing diff output ($diff_out) and $freebsd_diff"
+    diff "$diff_out" "$freebsd_diff"
+    echo "Success."
+    exit 0
+else
+    cat "$diff_out"
+fi
+
+exit 1


### PR DESCRIPTION
Finish work on PR #178 from Alan Somers (@asomers).

Fixes "CI is failing on FreeBSD 14 because there are a few new acl_ functions in that release that aren't known in bindgen/bindings_freebsd.rs."