### PR TITLE
Minor maintenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ scopeguard = "1.1.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [build-dependencies]
-bindgen = { version = "0.68.1", optional = true }
+bindgen = { version = "0.69.1", optional = true }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,23 +27,23 @@ default = []
 buildtime_bindgen = ["bindgen"]
 
 [dependencies]
-bitflags = "2.4.0"
-log = "0.4.11"
-uuid = "1.1.1"
-scopeguard = "1.1.0"
+bitflags = "2.4.1"
+log = "0.4.20"
+uuid = "1.6.1"
+scopeguard = "1.2.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [build-dependencies]
 bindgen = { version = "0.69.1", optional = true }
 
 [dev-dependencies]
-tempfile = "3.1.0"
-ctor = "0.2.2"
+tempfile = "3.8.1"
+ctor = "0.2.6"
 
 # Used by exacl.rs example.
-clap = { version = "4.0.23", features = ["derive"] }
-env_logger = "0.10.0"
-serde_json = "1.0.59"
+clap = { version = "4.4.11", features = ["derive"] }
+env_logger = "0.10.1"
+serde_json = "1.0.108"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]

--- a/build.rs
+++ b/build.rs
@@ -37,7 +37,7 @@ fn bindgen_bindings(wrapper: &str, out_path: &Path) {
     // crate when any included header file changes.
     let mut builder = bindgen::Builder::default()
         .header(wrapper)
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .disable_header_comment()
         .layout_tests(false); // no layout tests for passwd/group structs.
 

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -5,7 +5,7 @@
 set -eu
 
 # Space-separated list of ignored clippy lints.
-IGNORE="similar-names wildcard_imports use_self module_name_repetitions"
+IGNORE="similar-names wildcard_imports use_self module_name_repetitions needless_raw_string_hashes"
 
 allow=""
 for name in $IGNORE; do


### PR DESCRIPTION
- Update bindgen dev dependency and fix deprecation warning.
- Tell clippy to ignore the pedantic `needless_raw_string_hashes` warning.
- Update dependency versions in Cargo.toml.