### PR TITLE
Update CI to use FreeBSD 13.3, ubuntu-24.04, and macos-14.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,9 +5,9 @@ task:
   name: CI / build (freebsd)
 
   matrix:
-    - name: CI / build (freebsd-13.2)
+    - name: CI / build (freebsd-13.3)
       freebsd_instance:
-        image_family: freebsd-13-2
+        image_family: freebsd-13-3
     - name: CI / build (freebsd-14.0)
       freebsd_instance:
         image_family: freebsd-14-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install dependencies (Linux)
       run: |
         sudo apt-get update
-        sudo apt-get -y install libacl1-dev acl shunit2 valgrind shellcheck
+        sudo apt-get -y install libacl1-dev acl shunit2 shellcheck
       if: runner.os == 'Linux'
     - name: Fetch
       run: cargo fetch
@@ -53,7 +53,9 @@ jobs:
     - name: Run integration tests
       run: ./tests/run_tests.sh
     - name: Run memory tests (Linux)
-      run: ./tests/run_tests.sh memcheck
+      run: |
+        sudo apt-get install -y valgrind
+        ./tests/run_tests.sh memcheck
       if: runner.os == 'Linux'
     - name: Run TMPFS tests (Linux)
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
       run: |
         sudo apt-get install -y valgrind
         ./tests/run_tests.sh memcheck
-      if: runner.os == 'Linux'
+      # On ubuntu-24.04, installing valgrind leads to a "Restarting services..." cancelled error.
+      # For now, skip the memory test on ubuntu-24.04.
+      if: runner.os == 'Linux' && matrix.os != 'ubuntu-24.04'
     - name: Run TMPFS tests (Linux)
       run: |
         mkdir /run/user/$UID/exacl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, ubuntu-20.04, macos-12]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-14, macos-13, macos-12]
 
     steps:
     - name: Harden Runner


### PR DESCRIPTION
For now, skip the memory test (valgrind) on ubuntu-24.04. Installing valgrind triggers a `needrestart` issue which cancels the Github action. I will wait for a newer image before trying other work-arounds.