### PR TITLE
Fix minor issues.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,9 @@ jobs:
       run: ./tests/run_tests.sh
     - name: Run memory tests (Linux)
       run: |
-        sudo apt-get install -y valgrind
+        sudo NEEDRESTART_MODE=l apt-get install -y valgrind
         ./tests/run_tests.sh memcheck
-      # On ubuntu-24.04, installing valgrind leads to a "Restarting services..." cancelled error.
-      # For now, skip the memory test on ubuntu-24.04.
-      if: runner.os == 'Linux' && matrix.os != 'ubuntu-24.04'
+      if: runner.os == 'Linux'
     - name: Run TMPFS tests (Linux)
       run: |
         mkdir /run/user/$UID/exacl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [HEAD] - tbd
+
+- Update CI builds to use FreeBSD 13.3, ubuntu-24.04, and macos-14.
+- Update versions of Github Actions used in CI.
+- Update valgrind suppressions for newer versions of Rust.
+- Fix clippy warnings.
+
 ## [0.12.0] - 2024-02-02
 
 - Fix typo in rustdoc comments for getfacl/setfacl. (Thanks @sylvestre)

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -44,7 +44,7 @@ pub struct Acl {
     acl: acl_t,
 
     /// Set to true if `acl` was set from the default ACL for a directory
-    /// using DEFAULT_ACL option. Used to return entries with the `DEFAULT`
+    /// using `DEFAULT_ACL` option. Used to return entries with the `DEFAULT`
     /// flag set.
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     default_acl: bool,


### PR DESCRIPTION
- Fix valgrind install on ubuntu-24.04 using NEEDRESTART_MODE.
- Fix clippy warning on ubuntu.
- Bring release notes up to date.