### PR TITLE
Update rust edition to 2025 and MSRV to 1.85.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,14 @@ description = "Manipulate file system access control lists (ACL) on macOS, Linux
 repository = "https://github.com/byllyfish/exacl"
 documentation = "https://byllyfish.github.io/exacl"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 keywords = ["acl", "access", "control"]
 categories = ["filesystem"]
+
+# Consider updating rust version to new floor 6-12 months after release of a new edition.
+# Prefer a MSRV tied to edition boundary.
+
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/exacl.rs
+++ b/examples/exacl.rs
@@ -11,7 +11,7 @@
 //!
 //! To get/set the default ACL (on Linux), use the -d option.
 
-use exacl::{getfacl, setfacl, AclEntry, AclOption};
+use exacl::{AclEntry, AclOption, getfacl, setfacl};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process;

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -633,11 +633,9 @@ allow::other::read,write,execute
             let acl = Acl::from_entries(&entries).unwrap();
 
             #[cfg(target_os = "linux")]
-            let expected =
-                "allow::user::read\nallow::user:500:execute\nallow::group::read\nallow::mask::read,execute\nallow::other::read\n";
+            let expected = "allow::user::read\nallow::user:500:execute\nallow::group::read\nallow::mask::read,execute\nallow::other::read\n";
             #[cfg(target_os = "freebsd")]
-            let expected =
-                "allow::group::read\nallow::other::read\nallow::user:500:execute\nallow::user::read\nallow::mask::read,execute\n";
+            let expected = "allow::group::read\nallow::other::read\nallow::user:500:execute\nallow::user::read\nallow::mask::read,execute\n";
             assert_eq!(acl.to_string().unwrap(), expected);
 
             entries.push(AclEntry::allow_group("", Perm::WRITE, None));

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -490,7 +490,7 @@ deny:file_inherit,directory_inherit:group:11504:read,write,execute
 
         assert_eq!(
             acl.to_string()?,
-            r#"allow::user::read,write,execute
+            r"allow::user::read,write,execute
 allow::user:11501:read,write,execute
 allow::user:11502:read,write,execute
 allow::user:11503:read,write,execute
@@ -498,7 +498,7 @@ allow::group::read,write,execute
 allow::group:bin:read,write,execute
 allow::mask::read,write,execute
 allow::other::read,write,execute
-"#
+"
         );
 
         let acl2 = Acl::read(file.as_ref(), AclOption::empty())?;

--- a/src/aclentry.rs
+++ b/src/aclentry.rs
@@ -299,7 +299,7 @@ fn parse_allow(value: &str) -> Result<bool, format::Error> {
         s => {
             return Err(format::Error::Message(format!(
                 "Unknown variant `{s}`, expected one of `allow`, `deny`"
-            )))
+            )));
         }
     };
     Ok(result)

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -6,7 +6,7 @@ use crate::sys::*;
 
 use bitflags::bitflags;
 #[cfg(feature = "serde")]
-use serde::{de, ser, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de, ser};
 use std::fmt;
 
 bitflags! {
@@ -319,7 +319,10 @@ mod flag_tests {
                     .unwrap()
             );
 
-            assert_eq!("unknown variant `bad_flag`, expected one of `inherited`, `file_inherit`, `directory_inherit`, `limit_inherit`, `only_inherit`", "bad_flag".parse::<Flag>().unwrap_err().to_string());
+            assert_eq!(
+                "unknown variant `bad_flag`, expected one of `inherited`, `file_inherit`, `directory_inherit`, `limit_inherit`, `only_inherit`",
+                "bad_flag".parse::<Flag>().unwrap_err().to_string()
+            );
         }
 
         #[cfg(target_os = "linux")]

--- a/src/format/format_serde.rs
+++ b/src/format/format_serde.rs
@@ -2,7 +2,7 @@
 //! These are used when `serde` is available
 
 use serde::de::{self, IntoDeserializer, Visitor};
-use serde::{ser, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, ser};
 use std::fmt;
 use std::io;
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -8,12 +8,12 @@ mod format_no_serde;
 
 #[cfg(feature = "serde")]
 pub use format_serde::{
-    read_aclentrykind, read_flagname, read_permname, write_aclentrykind, write_flagname,
-    write_permname, Error,
+    Error, read_aclentrykind, read_flagname, read_permname, write_aclentrykind, write_flagname,
+    write_permname,
 };
 
 #[cfg(not(feature = "serde"))]
 pub use format_no_serde::{
-    read_aclentrykind, read_flagname, read_permname, write_aclentrykind, write_flagname,
-    write_permname, Error,
+    Error, read_aclentrykind, read_flagname, read_permname, write_aclentrykind, write_flagname,
+    write_permname,
 };

--- a/src/perm.rs
+++ b/src/perm.rs
@@ -6,7 +6,7 @@ use crate::sys::*;
 
 use bitflags::bitflags;
 #[cfg(feature = "serde")]
-use serde::{de, ser, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de, ser};
 use std::fmt;
 
 bitflags! {
@@ -408,13 +408,19 @@ mod perm_tests {
         assert_eq!(bad_perm.to_string(), "read");
 
         #[cfg(target_os = "macos")]
-        assert_eq!(Perm::all().to_string(), "read,write,execute,delete,append,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown,sync");
+        assert_eq!(
+            Perm::all().to_string(),
+            "read,write,execute,delete,append,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown,sync"
+        );
 
         #[cfg(target_os = "linux")]
         assert_eq!(Perm::all().to_string(), "read,write,execute");
 
         #[cfg(target_os = "freebsd")]
-        assert_eq!(Perm::all().to_string(), "read,write,execute,read_data,write_data,append,readextattr,writeextattr,delete_child,readattr,writeattr,delete,readsecurity,writesecurity,chown,sync");
+        assert_eq!(
+            Perm::all().to_string(),
+            "read,write,execute,read_data,write_data,append,readextattr,writeextattr,delete_child,readattr,writeattr,delete,readsecurity,writesecurity,chown,sync"
+        );
     }
 
     #[test]
@@ -433,7 +439,10 @@ mod perm_tests {
 
         #[cfg(target_os = "macos")]
         {
-            assert_eq!("unknown variant `q`, expected one of `read`, `write`, `execute`, `delete`, `append`, `delete_child`, `readattr`, `writeattr`, `readextattr`, `writeextattr`, `readsecurity`, `writesecurity`, `chown`, `sync`", " ,q ".parse::<Perm>().unwrap_err().to_string());
+            assert_eq!(
+                "unknown variant `q`, expected one of `read`, `write`, `execute`, `delete`, `append`, `delete_child`, `readattr`, `writeattr`, `readextattr`, `writeextattr`, `readsecurity`, `writesecurity`, `chown`, `sync`",
+                " ,q ".parse::<Perm>().unwrap_err().to_string()
+            );
 
             assert_eq!(Perm::all(), "read,write,execute,delete,append,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown,sync".parse().unwrap());
         }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -27,7 +27,7 @@ pub const ACL_MAX_ENTRIES: u32 = 2_000_000_000;
 // MacOS and FreeBSD use acl_get_perm_np().
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 pub unsafe fn acl_get_perm(permset_d: acl_permset_t, perm: acl_perm_t) -> ::std::os::raw::c_int {
-    acl_get_perm_np(permset_d, perm)
+    unsafe { acl_get_perm_np(permset_d, perm) }
 }
 
 /// Non-portable ACL Permissions & Flags (`macOS` only)

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -246,7 +246,7 @@ pub fn guid_to_id(guid: Uuid) -> io::Result<(Option<uid_t>, Option<gid_t>)> {
         _ => {
             return fail_custom(&format!(
                 "mbr_uuid_to_id: Unknown idtype {idtype:?} for guid {guid:?}"
-            ))
+            ));
         }
     };
 

--- a/src/util/util_freebsd.rs
+++ b/src/util/util_freebsd.rs
@@ -239,7 +239,7 @@ fn xacl_get_qualifier(entry: acl_entry_t) -> io::Result<Qualifier> {
 fn xacl_get_entry_type(entry: acl_entry_t) -> io::Result<acl_entry_type_t> {
     let mut entry_type: acl_entry_type_t = 0;
 
-    let ret = unsafe { acl_get_entry_type_np(entry, &mut entry_type) };
+    let ret = unsafe { acl_get_entry_type_np(entry, &raw mut entry_type) };
     if ret != 0 {
         return fail_err(ret, "acl_get_entry_type_np", ());
     }
@@ -272,7 +272,7 @@ fn xacl_get_flags(acl: acl_t, entry: acl_entry_t) -> io::Result<Flag> {
     }
 
     let mut flagset: acl_flagset_t = std::ptr::null_mut();
-    let ret = unsafe { acl_get_flagset_np(entry, &mut flagset) };
+    let ret = unsafe { acl_get_flagset_np(entry, &raw mut flagset) };
     if ret != 0 {
         return fail_err(ret, "acl_get_flagset_np", ());
     }
@@ -326,7 +326,7 @@ pub fn xacl_set_tag_qualifier(
 ) -> io::Result<()> {
     if !allow {
         xacl_set_entry_type(entry, sg::ACL_ENTRY_TYPE_DENY)?;
-    };
+    }
 
     match qualifier {
         Qualifier::User(uid) => {
@@ -366,7 +366,7 @@ fn xacl_set_flags(entry: acl_entry_t, flags: Flag) -> io::Result<()> {
     }
 
     let mut flagset: acl_flagset_t = std::ptr::null_mut();
-    let ret_get = unsafe { acl_get_flagset_np(entry, &mut flagset) };
+    let ret_get = unsafe { acl_get_flagset_np(entry, &raw mut flagset) };
     if ret_get != 0 {
         return fail_err(ret_get, "acl_get_flagset_np", ());
     }
@@ -428,7 +428,7 @@ pub fn xacl_add_entry(
 
 fn xacl_get_brand(acl: acl_t) -> io::Result<i32> {
     let mut brand: i32 = 0;
-    let ret = unsafe { acl_get_brand_np(acl, &mut brand) };
+    let ret = unsafe { acl_get_brand_np(acl, &raw mut brand) };
     if ret != 0 {
         return fail_err(ret, "acl_get_brand_np", ());
     }
@@ -456,7 +456,7 @@ fn log_brand(func: &str, acl: acl_t) -> io::Result<()> {
         value => value.to_string(),
     };
 
-    debug!("{}: acl {}", func, brand);
+    debug!("{func}: acl {brand}");
 
     Ok(())
 }

--- a/src/util/util_freebsd.rs
+++ b/src/util/util_freebsd.rs
@@ -8,7 +8,7 @@ use crate::util::util_common;
 
 use log::debug;
 use scopeguard::defer;
-use std::ffi::{c_void, CString};
+use std::ffi::{CString, c_void};
 use std::io;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;

--- a/src/util/util_linux.rs
+++ b/src/util/util_linux.rs
@@ -6,7 +6,7 @@ use crate::sys::*;
 use crate::util::util_common;
 
 use scopeguard::defer;
-use std::ffi::{c_void, CString};
+use std::ffi::{CString, c_void};
 use std::io;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;

--- a/src/util/util_macos.rs
+++ b/src/util/util_macos.rs
@@ -7,7 +7,7 @@ use crate::sys::*;
 use crate::util::util_common;
 
 use scopeguard::defer;
-use std::ffi::{c_void, CString};
+use std::ffi::{CString, c_void};
 use std::io;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,7 +1,7 @@
 //! API Tests for exacl module.
 
 use ctor::ctor;
-use exacl::{getfacl, setfacl, AclEntry, AclOption, Perm};
+use exacl::{AclEntry, AclOption, Perm, getfacl, setfacl};
 use log::debug;
 use std::io;
 
@@ -27,20 +27,24 @@ fn test_getfacl_file() -> io::Result<()> {
     #[cfg(target_os = "macos")]
     {
         let result = getfacl(&file, AclOption::DEFAULT_ACL);
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("macOS does not support default ACL"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("macOS does not support default ACL")
+        );
     }
 
     // Test default ACL (should be error; files don't have default ACL).
     #[cfg(target_os = "linux")]
     {
         let result = getfacl(&file, AclOption::DEFAULT_ACL);
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Permission denied"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Permission denied")
+        );
     }
 
     // Test default ACL (should be error; files don't have default ACL).
@@ -241,7 +245,10 @@ fn test_exclusive_acloptions() {
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn test_from_mode() {
     let acl_7777 = exacl::to_string(&exacl::from_mode(0o7777)).unwrap();
-    assert_eq!(acl_7777, "allow::user::read,write,execute\nallow::group::read,write,execute\nallow::other::read,write,execute\n");
+    assert_eq!(
+        acl_7777,
+        "allow::user::read,write,execute\nallow::group::read,write,execute\nallow::other::read,write,execute\n"
+    );
 
     let acl_000 = exacl::to_string(&exacl::from_mode(0o000)).unwrap();
     assert_eq!(acl_000, "allow::user::\nallow::group::\nallow::other::\n");

--- a/tests/test_examples.rs
+++ b/tests/test_examples.rs
@@ -61,7 +61,10 @@ fn test_linux_acl_default() -> io::Result<()> {
     }
     acl.append(&mut default_acl);
 
-    assert_eq!(exacl::to_string(&acl)?, "allow::user::read,write,execute\nallow::group::read,write,execute\nallow::other::\nallow::group:accounting:read,write,execute\nallow:default:user::read,write,execute\nallow:default:group::read,write,execute\nallow:default:other::\nallow:default:group:accounting:read,write,execute\n");
+    assert_eq!(
+        exacl::to_string(&acl)?,
+        "allow::user::read,write,execute\nallow::group::read,write,execute\nallow::other::\nallow::group:accounting:read,write,execute\nallow:default:user::read,write,execute\nallow:default:group::read,write,execute\nallow:default:other::\nallow:default:group:accounting:read,write,execute\n"
+    );
     //exacl::setfacl(&["./tmp/dir"], &acl, None)?;
 
     Ok(())


### PR DESCRIPTION
- Re-run cargo fmt.
- Fix a new compiler warning.
- More clippy fixes.