### PR TITLE
Add safe macOS fd ACL presence query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+- Add a safe macOS-only `extended_acl_presence` API that inspects a retained
+  file descriptor directly without re-resolving a pathname or decoding entries.
+
 ## [0.13.0] - 2026-05-05
 
 - No new features. No bugs fixed. Maintenance changes only.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,16 @@ setfacl(&["./tmp/foo"], &acl, None)?;
 
 ## API
 
-This module provides two high level functions, `getfacl` and `setfacl`.
+This module provides two cross-platform, path-based high level functions,
+`getfacl` and `setfacl`.
 
 - `getfacl` retrieves the ACL for a file or directory.
 - `setfacl` sets the ACL for files or directories.
+
+On macOS, `extended_acl_presence` safely detects an extended ACL through an
+already-open file descriptor without re-resolving a pathname. Only the native
+no-ACL result is reported as absent; every other inspection failure is returned
+as an error.
 
 On Linux and FreeBSD, the ACL contains entries for the default ACL, if
 present.

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -13,6 +13,7 @@ use crate::util::*;
 use bitflags::bitflags;
 use scopeguard::{self, ScopeGuard};
 use std::io;
+use std::os::fd::BorrowedFd;
 use std::path::Path;
 
 bitflags! {
@@ -59,6 +60,25 @@ impl Acl {
             acl,
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
             default_acl,
+        }
+    }
+
+    /// Return true if the file descriptor has an ACL that extends the base
+    /// permissions of the file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`io::Error`] on failure.
+    pub fn exists_fd(fd: BorrowedFd<'_>, _options: AclOption) -> io::Result<bool> {
+        // TODO: Handle options.
+        #[cfg(target_os = "macos")]
+        {
+            xacl_exists_fd(fd)
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            fail_custom("`exists_fd` is only implemented on macOS")
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,6 @@ use std::path::Path;
 use failx::fail_custom;
 
 /// Whether a macOS filesystem object has an extended access control list.
-#[cfg(any(docsrs, target_os = "macos"))]
-#[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[must_use = "the observed ACL presence must be handled"]
 pub enum ExtendedAclPresence {
@@ -109,21 +107,11 @@ pub enum ExtendedAclPresence {
 /// Returns an [`io::Error`] when ACL retrieval fails for any reason other than
 /// macOS reporting that no extended ACL is attached, or when releasing the
 /// native ACL object fails.
-#[cfg(any(docsrs, target_os = "macos"))]
-#[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
 pub fn extended_acl_presence(fd: BorrowedFd<'_>) -> io::Result<ExtendedAclPresence> {
-    #[cfg(target_os = "macos")]
-    {
-        util::xacl_extended_acl_presence(fd)
-    }
-
-    #[cfg(all(docsrs, not(target_os = "macos")))]
-    {
-        let _ = fd;
-        Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "extended ACL presence is only available on macOS",
-        ))
+    if Acl::exists_fd(fd, AclOption::empty())? {
+        Ok(ExtendedAclPresence::Present)
+    } else {
+        Ok(ExtendedAclPresence::Absent)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,14 @@
 //!
 //! ## API
 //!
-//! This module provides two high level functions, [`getfacl`] and [`setfacl`].
+//! This module provides two cross-platform, path-based high level functions,
+//! [`getfacl`] and [`setfacl`].
 //!
 //! - [`getfacl`] retrieves the ACL for a file or directory.
 //! - [`setfacl`] sets the ACL for files or directories.
+//!
+//! On macOS, [`extended_acl_presence`] safely detects an extended ACL through
+//! an already-open file descriptor without re-resolving a pathname.
 //!
 //! On Linux and `FreeBSD`, the ACL contains entries for the default ACL, if
 //! present.
@@ -73,10 +77,55 @@ pub use perm::Perm;
 use acl::Acl;
 use failx::custom_err;
 use std::io::{self, BufRead};
+#[cfg(any(docsrs, target_os = "macos"))]
+use std::os::fd::BorrowedFd;
 use std::path::Path;
 
 #[cfg(not(target_os = "macos"))]
 use failx::fail_custom;
+
+/// Whether a macOS filesystem object has an extended access control list.
+#[cfg(any(docsrs, target_os = "macos"))]
+#[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[must_use = "the observed ACL presence must be handled"]
+pub enum ExtendedAclPresence {
+    /// No extended ACL is attached to the object.
+    Absent,
+    /// An extended ACL is attached to the object.
+    Present,
+}
+
+/// Detect whether the object referenced by `fd` has a macOS extended ACL.
+///
+/// This queries the retained descriptor directly. It does not resolve a
+/// pathname, duplicate or close the descriptor, or decode ACL entries.
+///
+/// The result is a point-in-time observation. Another process with sufficient
+/// authority may alter the ACL after this function returns.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] when ACL retrieval fails for any reason other than
+/// macOS reporting that no extended ACL is attached, or when releasing the
+/// native ACL object fails.
+#[cfg(any(docsrs, target_os = "macos"))]
+#[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
+pub fn extended_acl_presence(fd: BorrowedFd<'_>) -> io::Result<ExtendedAclPresence> {
+    #[cfg(target_os = "macos")]
+    {
+        util::xacl_extended_acl_presence(fd)
+    }
+
+    #[cfg(all(docsrs, not(target_os = "macos")))]
+    {
+        let _ = fd;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "extended ACL presence is only available on macOS",
+        ))
+    }
+}
 
 /// Get access control list (ACL) for a file or directory.
 ///

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -15,6 +15,7 @@
 //!    `xacl_get_file`  - get ACL from file path
 //!    `xacl_set_file`  - set ACL for file path
 //!    `xacl_is_nfs4`   - return true if file path uses `NFSv4` ACL on `FreeBSD`
+//!    `xacl_exists_fd` - return true if file descriptor has an ACL beyond base permissions
 
 mod util_common;
 
@@ -44,9 +45,6 @@ pub use util_linux::{
 
 #[cfg(target_os = "macos")]
 pub use util_macos::{
-    xacl_add_entry, xacl_foreach, xacl_free, xacl_get_entry, xacl_get_file, xacl_init,
-    xacl_is_empty, xacl_is_posix, xacl_set_file,
+    xacl_add_entry, xacl_exists_fd, xacl_foreach, xacl_free, xacl_get_entry, xacl_get_file,
+    xacl_init, xacl_is_empty, xacl_is_posix, xacl_set_file,
 };
-
-#[cfg(target_os = "macos")]
-pub(crate) use util_macos::xacl_extended_acl_presence;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -47,3 +47,6 @@ pub use util_macos::{
     xacl_add_entry, xacl_foreach, xacl_free, xacl_get_entry, xacl_get_file, xacl_init,
     xacl_is_empty, xacl_is_posix, xacl_set_file,
 };
+
+#[cfg(target_os = "macos")]
+pub(crate) use util_macos::xacl_extended_acl_presence;

--- a/src/util/util_macos.rs
+++ b/src/util/util_macos.rs
@@ -1,3 +1,4 @@
+use crate::ExtendedAclPresence;
 use crate::bititer::BitIter;
 use crate::failx::*;
 use crate::flag::Flag;
@@ -9,6 +10,8 @@ use crate::util::util_common;
 use scopeguard::defer;
 use std::ffi::{CString, c_void};
 use std::io;
+use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
+use std::os::raw::c_int;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use uuid::Uuid;
@@ -24,6 +27,57 @@ fn path_exists(path: &Path, symlink_only: bool) -> bool {
     } else {
         path.exists()
     }
+}
+
+pub(crate) fn xacl_extended_acl_presence(fd: BorrowedFd<'_>) -> io::Result<ExtendedAclPresence> {
+    xacl_extended_acl_presence_with(
+        fd.as_raw_fd(),
+        |raw_fd, acl_type| {
+            // SAFETY: `BorrowedFd` keeps `raw_fd` open for this call, Darwin's
+            // getter does not retain it, and `acl_type` is the platform's valid
+            // extended-ACL constant.
+            unsafe { acl_get_fd_np(raw_fd, acl_type) }
+        },
+        |acl| {
+            // SAFETY: `acl` is the non-null allocation returned by the getter.
+            // It has not been freed or otherwise used, this closure is invoked
+            // exactly once, and the pointer is never used after this call.
+            unsafe { crate::sys::acl_free(acl.cast::<c_void>()) }
+        },
+        io::Error::last_os_error,
+    )
+}
+
+fn xacl_extended_acl_presence_with<GetAcl, FreeAcl, LastOsError>(
+    fd: RawFd,
+    get_acl: GetAcl,
+    free_acl: FreeAcl,
+    mut last_os_error: LastOsError,
+) -> io::Result<ExtendedAclPresence>
+where
+    GetAcl: FnOnce(RawFd, acl_type_t) -> acl_t,
+    FreeAcl: FnOnce(acl_t) -> c_int,
+    LastOsError: FnMut() -> io::Error,
+{
+    let acl = get_acl(fd, sg::ACL_TYPE_EXTENDED);
+    if acl.is_null() {
+        let error = last_os_error();
+        log::debug!("acl_get_fd_np({fd}, ACL_TYPE_EXTENDED) returned null: {error}");
+        return if error.raw_os_error() == Some(sg::ENOENT) {
+            Ok(ExtendedAclPresence::Absent)
+        } else {
+            Err(error)
+        };
+    }
+
+    let free_result = free_acl(acl);
+    if free_result != 0 {
+        let error = last_os_error();
+        log::debug!("acl_free returned {free_result}: {error}");
+        return Err(error);
+    }
+
+    Ok(ExtendedAclPresence::Present)
 }
 
 /// Get the native ACL for a specific file or directory.
@@ -261,6 +315,162 @@ pub const fn xacl_is_posix(_acl: acl_t) -> bool {
 #[cfg(test)]
 mod util_macos_test {
     use super::*;
+    use std::cell::Cell;
+
+    fn fake_acl() -> acl_t {
+        std::ptr::NonNull::<_acl>::dangling().as_ptr()
+    }
+
+    #[test]
+    fn fd_acl_presence_maps_null_enoent_to_absent_without_freeing() {
+        let free_calls = Cell::new(0);
+        let errno_calls = Cell::new(0);
+
+        let presence = xacl_extended_acl_presence_with(
+            41,
+            |fd, acl_type| {
+                assert_eq!(fd, 41);
+                assert_eq!(acl_type, sg::ACL_TYPE_EXTENDED);
+                std::ptr::null_mut()
+            },
+            |_| {
+                free_calls.set(free_calls.get() + 1);
+                0
+            },
+            || {
+                errno_calls.set(errno_calls.get() + 1);
+                io::Error::from_raw_os_error(sg::ENOENT)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(presence, ExtendedAclPresence::Absent);
+        assert_eq!(free_calls.get(), 0);
+        assert_eq!(errno_calls.get(), 1);
+    }
+
+    #[test]
+    fn fd_acl_presence_preserves_null_error_without_freeing() {
+        let free_calls = Cell::new(0);
+        let errno_calls = Cell::new(0);
+
+        let error = xacl_extended_acl_presence_with(
+            42,
+            |fd, acl_type| {
+                assert_eq!(fd, 42);
+                assert_eq!(acl_type, sg::ACL_TYPE_EXTENDED);
+                std::ptr::null_mut()
+            },
+            |_| {
+                free_calls.set(free_calls.get() + 1);
+                0
+            },
+            || {
+                errno_calls.set(errno_calls.get() + 1);
+                io::Error::from_raw_os_error(sg::ENOTSUP)
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error.raw_os_error(), Some(sg::ENOTSUP));
+        assert_eq!(free_calls.get(), 0);
+        assert_eq!(errno_calls.get(), 1);
+    }
+
+    #[test]
+    fn fd_acl_presence_rejects_every_other_null_errno() {
+        const DARWIN_EBADF: i32 = 9;
+        const DARWIN_EOPNOTSUPP: i32 = 102;
+
+        for raw_errno in [
+            DARWIN_EBADF,
+            sg::EINVAL,
+            sg::ENOMEM,
+            DARWIN_EOPNOTSUPP,
+            sg::ENOTSUP,
+            0,
+        ] {
+            let free_calls = Cell::new(0);
+            let errno_calls = Cell::new(0);
+            let error = xacl_extended_acl_presence_with(
+                45,
+                |_, _| std::ptr::null_mut(),
+                |_| {
+                    free_calls.set(free_calls.get() + 1);
+                    0
+                },
+                || {
+                    errno_calls.set(errno_calls.get() + 1);
+                    io::Error::from_raw_os_error(raw_errno)
+                },
+            )
+            .unwrap_err();
+
+            assert_eq!(error.raw_os_error(), Some(raw_errno));
+            assert_eq!(free_calls.get(), 0);
+            assert_eq!(errno_calls.get(), 1);
+        }
+    }
+
+    #[test]
+    fn fd_acl_presence_reports_present_and_frees_exactly_once() {
+        let expected_acl = fake_acl();
+        let free_calls = Cell::new(0);
+        let errno_calls = Cell::new(0);
+
+        let presence = xacl_extended_acl_presence_with(
+            43,
+            |fd, acl_type| {
+                assert_eq!(fd, 43);
+                assert_eq!(acl_type, sg::ACL_TYPE_EXTENDED);
+                expected_acl
+            },
+            |acl| {
+                assert_eq!(acl, expected_acl);
+                free_calls.set(free_calls.get() + 1);
+                0
+            },
+            || {
+                errno_calls.set(errno_calls.get() + 1);
+                io::Error::from_raw_os_error(sg::EINVAL)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(presence, ExtendedAclPresence::Present);
+        assert_eq!(free_calls.get(), 1);
+        assert_eq!(errno_calls.get(), 0);
+    }
+
+    #[test]
+    fn fd_acl_presence_preserves_free_error_without_retrying() {
+        let expected_acl = fake_acl();
+        let free_calls = Cell::new(0);
+        let errno_calls = Cell::new(0);
+
+        let error = xacl_extended_acl_presence_with(
+            44,
+            |fd, acl_type| {
+                assert_eq!(fd, 44);
+                assert_eq!(acl_type, sg::ACL_TYPE_EXTENDED);
+                expected_acl
+            },
+            |acl| {
+                assert_eq!(acl, expected_acl);
+                free_calls.set(free_calls.get() + 1);
+                -1
+            },
+            || {
+                errno_calls.set(errno_calls.get() + 1);
+                io::Error::from_raw_os_error(sg::EINVAL)
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error.raw_os_error(), Some(sg::EINVAL));
+        assert_eq!(free_calls.get(), 1);
+        assert_eq!(errno_calls.get(), 1);
+    }
 
     #[test]
     fn test_acl_init() {

--- a/src/util/util_macos.rs
+++ b/src/util/util_macos.rs
@@ -1,4 +1,3 @@
-use crate::ExtendedAclPresence;
 use crate::bititer::BitIter;
 use crate::failx::*;
 use crate::flag::Flag;
@@ -10,8 +9,7 @@ use crate::util::util_common;
 use scopeguard::defer;
 use std::ffi::{CString, c_void};
 use std::io;
-use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
-use std::os::raw::c_int;
+use std::os::fd::{AsRawFd, BorrowedFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use uuid::Uuid;
@@ -29,55 +27,23 @@ fn path_exists(path: &Path, symlink_only: bool) -> bool {
     }
 }
 
-pub(crate) fn xacl_extended_acl_presence(fd: BorrowedFd<'_>) -> io::Result<ExtendedAclPresence> {
-    xacl_extended_acl_presence_with(
-        fd.as_raw_fd(),
-        |raw_fd, acl_type| {
-            // SAFETY: `BorrowedFd` keeps `raw_fd` open for this call, Darwin's
-            // getter does not retain it, and `acl_type` is the platform's valid
-            // extended-ACL constant.
-            unsafe { acl_get_fd_np(raw_fd, acl_type) }
-        },
-        |acl| {
-            // SAFETY: `acl` is the non-null allocation returned by the getter.
-            // It has not been freed or otherwise used, this closure is invoked
-            // exactly once, and the pointer is never used after this call.
-            unsafe { crate::sys::acl_free(acl.cast::<c_void>()) }
-        },
-        io::Error::last_os_error,
-    )
-}
+/// Check if there is a native ACL for the given file descriptor. If the file
+/// has an ACL beyond the base permissions, return `true`.
+pub fn xacl_exists_fd(fd: BorrowedFd<'_>) -> io::Result<bool> {
+    let raw_fd = fd.as_raw_fd();
+    let acl = unsafe { acl_get_fd_np(raw_fd, acl_type_t_ACL_TYPE_EXTENDED) };
 
-fn xacl_extended_acl_presence_with<GetAcl, FreeAcl, LastOsError>(
-    fd: RawFd,
-    get_acl: GetAcl,
-    free_acl: FreeAcl,
-    mut last_os_error: LastOsError,
-) -> io::Result<ExtendedAclPresence>
-where
-    GetAcl: FnOnce(RawFd, acl_type_t) -> acl_t,
-    FreeAcl: FnOnce(acl_t) -> c_int,
-    LastOsError: FnMut() -> io::Error,
-{
-    let acl = get_acl(fd, sg::ACL_TYPE_EXTENDED);
     if acl.is_null() {
-        let error = last_os_error();
-        log::debug!("acl_get_fd_np({fd}, ACL_TYPE_EXTENDED) returned null: {error}");
-        return if error.raw_os_error() == Some(sg::ENOENT) {
-            Ok(ExtendedAclPresence::Absent)
-        } else {
-            Err(error)
-        };
+        let err = log_err("null", "acl_get_fd_np", raw_fd);
+        if err.raw_os_error() == Some(sg::ENOENT) {
+            // `ENOENT` means there is no "extended" ACL.
+            return Ok(false);
+        }
+        return Err(err);
     }
 
-    let free_result = free_acl(acl);
-    if free_result != 0 {
-        let error = last_os_error();
-        log::debug!("acl_free returned {free_result}: {error}");
-        return Err(error);
-    }
-
-    Ok(ExtendedAclPresence::Present)
+    xacl_free(acl);
+    Ok(true)
 }
 
 /// Get the native ACL for a specific file or directory.
@@ -315,162 +281,6 @@ pub const fn xacl_is_posix(_acl: acl_t) -> bool {
 #[cfg(test)]
 mod util_macos_test {
     use super::*;
-    use std::cell::Cell;
-
-    fn fake_acl() -> acl_t {
-        std::ptr::NonNull::<_acl>::dangling().as_ptr()
-    }
-
-    #[test]
-    fn fd_acl_presence_maps_null_enoent_to_absent_without_freeing() {
-        let free_calls = Cell::new(0);
-        let errno_calls = Cell::new(0);
-
-        let presence = xacl_extended_acl_presence_with(
-            41,
-            |fd, acl_type| {
-                assert_eq!(fd, 41);
-                assert_eq!(acl_type, sg::ACL_TYPE_EXTENDED);
-                std::ptr::null_mut()
-            },
-            |_| {
-                free_calls.set(free_calls.get() + 1);
-                0
-            },
-            || {
-                errno_calls.set(errno_calls.get() + 1);
-                io::Error::from_raw_os_error(sg::ENOENT)
-            },
-        )
-        .unwrap();
-
-        assert_eq!(presence, ExtendedAclPresence::Absent);
-        assert_eq!(free_calls.get(), 0);
-        assert_eq!(errno_calls.get(), 1);
-    }
-
-    #[test]
-    fn fd_acl_presence_preserves_null_error_without_freeing() {
-        let free_calls = Cell::new(0);
-        let errno_calls = Cell::new(0);
-
-        let error = xacl_extended_acl_presence_with(
-            42,
-            |fd, acl_type| {
-                assert_eq!(fd, 42);
-                assert_eq!(acl_type, sg::ACL_TYPE_EXTENDED);
-                std::ptr::null_mut()
-            },
-            |_| {
-                free_calls.set(free_calls.get() + 1);
-                0
-            },
-            || {
-                errno_calls.set(errno_calls.get() + 1);
-                io::Error::from_raw_os_error(sg::ENOTSUP)
-            },
-        )
-        .unwrap_err();
-
-        assert_eq!(error.raw_os_error(), Some(sg::ENOTSUP));
-        assert_eq!(free_calls.get(), 0);
-        assert_eq!(errno_calls.get(), 1);
-    }
-
-    #[test]
-    fn fd_acl_presence_rejects_every_other_null_errno() {
-        const DARWIN_EBADF: i32 = 9;
-        const DARWIN_EOPNOTSUPP: i32 = 102;
-
-        for raw_errno in [
-            DARWIN_EBADF,
-            sg::EINVAL,
-            sg::ENOMEM,
-            DARWIN_EOPNOTSUPP,
-            sg::ENOTSUP,
-            0,
-        ] {
-            let free_calls = Cell::new(0);
-            let errno_calls = Cell::new(0);
-            let error = xacl_extended_acl_presence_with(
-                45,
-                |_, _| std::ptr::null_mut(),
-                |_| {
-                    free_calls.set(free_calls.get() + 1);
-                    0
-                },
-                || {
-                    errno_calls.set(errno_calls.get() + 1);
-                    io::Error::from_raw_os_error(raw_errno)
-                },
-            )
-            .unwrap_err();
-
-            assert_eq!(error.raw_os_error(), Some(raw_errno));
-            assert_eq!(free_calls.get(), 0);
-            assert_eq!(errno_calls.get(), 1);
-        }
-    }
-
-    #[test]
-    fn fd_acl_presence_reports_present_and_frees_exactly_once() {
-        let expected_acl = fake_acl();
-        let free_calls = Cell::new(0);
-        let errno_calls = Cell::new(0);
-
-        let presence = xacl_extended_acl_presence_with(
-            43,
-            |fd, acl_type| {
-                assert_eq!(fd, 43);
-                assert_eq!(acl_type, sg::ACL_TYPE_EXTENDED);
-                expected_acl
-            },
-            |acl| {
-                assert_eq!(acl, expected_acl);
-                free_calls.set(free_calls.get() + 1);
-                0
-            },
-            || {
-                errno_calls.set(errno_calls.get() + 1);
-                io::Error::from_raw_os_error(sg::EINVAL)
-            },
-        )
-        .unwrap();
-
-        assert_eq!(presence, ExtendedAclPresence::Present);
-        assert_eq!(free_calls.get(), 1);
-        assert_eq!(errno_calls.get(), 0);
-    }
-
-    #[test]
-    fn fd_acl_presence_preserves_free_error_without_retrying() {
-        let expected_acl = fake_acl();
-        let free_calls = Cell::new(0);
-        let errno_calls = Cell::new(0);
-
-        let error = xacl_extended_acl_presence_with(
-            44,
-            |fd, acl_type| {
-                assert_eq!(fd, 44);
-                assert_eq!(acl_type, sg::ACL_TYPE_EXTENDED);
-                expected_acl
-            },
-            |acl| {
-                assert_eq!(acl, expected_acl);
-                free_calls.set(free_calls.get() + 1);
-                -1
-            },
-            || {
-                errno_calls.set(errno_calls.get() + 1);
-                io::Error::from_raw_os_error(sg::EINVAL)
-            },
-        )
-        .unwrap_err();
-
-        assert_eq!(error.raw_os_error(), Some(sg::EINVAL));
-        assert_eq!(free_calls.get(), 1);
-        assert_eq!(errno_calls.get(), 1);
-    }
 
     #[test]
     fn test_acl_init() {

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -33,37 +33,36 @@ fn persistent_acl_fixture(label: &str) -> PathBuf {
     ))
 }
 
-#[test]
 #[cfg(target_os = "macos")]
-#[ignore = "physical macOS ACL receipt; retains its unique fixtures for inspection"]
-fn physical_extended_acl_presence_is_bound_to_the_retained_fd() -> io::Result<()> {
-    let principal = std::env::var("USER").map_err(|error| {
+fn acl_principal() -> io::Result<String> {
+    std::env::var("USER").map_err(|error| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
             format!("USER must identify an ACL principal: {error}"),
         )
-    })?;
-    let original_path = persistent_acl_fixture("original");
-    let retained_path = persistent_acl_fixture("retained");
-    let inverse_original_path = persistent_acl_fixture("inverse-original");
-    let inverse_retained_path = persistent_acl_fixture("inverse-retained");
-    let inherited_dir = persistent_acl_fixture("inherited-dir");
-    let inherited_child = inherited_dir.join("child");
-    let inherited_child_dir = inherited_dir.join("child-dir");
+    })
+}
 
+#[cfg(target_os = "macos")]
+fn announce_physical_fixtures(fixtures: &[&PathBuf]) {
     eprintln!(
         "physical ACL receipt platform: os={} arch={}",
         std::env::consts::OS,
         std::env::consts::ARCH
     );
-    eprintln!(
-        "retained physical ACL fixtures: {}, {}, {}, {}, {}",
-        original_path.display(),
-        retained_path.display(),
-        inverse_original_path.display(),
-        inverse_retained_path.display(),
-        inherited_dir.display()
-    );
+    for fixture in fixtures {
+        eprintln!("retained physical ACL fixture: {}", fixture.display());
+    }
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+#[ignore = "physical macOS ACL receipt; retains its unique fixtures for inspection"]
+fn physical_file_acl_lifecycle_tracks_the_retained_fd() -> io::Result<()> {
+    let principal = acl_principal()?;
+    let original_path = persistent_acl_fixture("lifecycle-original");
+    let renamed_path = persistent_acl_fixture("lifecycle-renamed");
+    announce_physical_fixtures(&[&original_path, &renamed_path]);
 
     let _original_creator = File::create_new(&original_path)?;
     let retained = File::open(&original_path)?;
@@ -80,7 +79,6 @@ fn physical_extended_acl_presence_is_bound_to_the_retained_fd() -> io::Result<()
         ExtendedAclPresence::Present,
         "an ALLOW ACL must report Present through the retained read-only descriptor"
     );
-    retained.metadata()?;
 
     let deny = AclEntry::deny_user(&principal, Perm::WRITE, None::<Flag>);
     setfacl(&[&original_path], &[deny], None)?;
@@ -97,8 +95,11 @@ fn physical_extended_acl_presence_is_bound_to_the_retained_fd() -> io::Result<()
         "clearing the ACL must return the retained descriptor to Absent"
     );
 
+    // The retained descriptor must track its file object, not its pathname:
+    // re-apply an ACL, move the file away, and put a clean file at the old
+    // name. Retained reports Present; the clean replacement reports Absent.
     setfacl(&[&original_path], &[allow], None)?;
-    std::fs::rename(&original_path, &retained_path)?;
+    std::fs::rename(&original_path, &renamed_path)?;
     let _replacement_creator = File::create_new(&original_path)?;
     let replacement = File::open(&original_path)?;
     assert_eq!(
@@ -111,6 +112,48 @@ fn physical_extended_acl_presence_is_bound_to_the_retained_fd() -> io::Result<()
         ExtendedAclPresence::Absent,
         "the read-only replacement descriptor must remain ACL-free"
     );
+    Ok(())
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+#[ignore = "physical macOS ACL receipt; retains its unique fixtures for inspection"]
+fn physical_acl_bearing_replacement_does_not_leak_into_the_retained_fd() -> io::Result<()> {
+    let principal = acl_principal()?;
+    let original_path = persistent_acl_fixture("inverse-original");
+    let renamed_path = persistent_acl_fixture("inverse-renamed");
+    announce_physical_fixtures(&[&original_path, &renamed_path]);
+
+    let _original_creator = File::create_new(&original_path)?;
+    let retained = File::open(&original_path)?;
+    std::fs::rename(&original_path, &renamed_path)?;
+    let _replacement_creator = File::create_new(&original_path)?;
+    let replacement = File::open(&original_path)?;
+
+    let allow = AclEntry::allow_user(&principal, Perm::READ, None::<Flag>);
+    setfacl(&[&original_path], &[allow], None::<AclOption>)?;
+    assert_eq!(
+        extended_acl_presence(retained.as_fd())?,
+        ExtendedAclPresence::Absent,
+        "an ACL-bearing replacement must not alter the retained original descriptor"
+    );
+    assert_eq!(
+        extended_acl_presence(replacement.as_fd())?,
+        ExtendedAclPresence::Present,
+        "the ACL-bearing read-only replacement descriptor must report Present"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+#[ignore = "physical macOS ACL receipt; retains its unique fixtures for inspection"]
+fn physical_directory_inheritance_is_observed_through_retained_fds() -> io::Result<()> {
+    let principal = acl_principal()?;
+    let inherited_dir = persistent_acl_fixture("inherited-dir");
+    let inherited_child = inherited_dir.join("child");
+    let inherited_child_dir = inherited_dir.join("child-dir");
+    announce_physical_fixtures(&[&inherited_dir]);
 
     std::fs::create_dir(&inherited_dir)?;
     let clean_directory = File::open(&inherited_dir)?;
@@ -119,6 +162,7 @@ fn physical_extended_acl_presence_is_bound_to_the_retained_fd() -> io::Result<()
         ExtendedAclPresence::Absent,
         "a clean read-only directory descriptor must report Absent"
     );
+
     let inheritable = AclEntry::allow_user(
         &principal,
         Perm::READ,
@@ -138,28 +182,6 @@ fn physical_extended_acl_presence_is_bound_to_the_retained_fd() -> io::Result<()
         extended_acl_presence(child_directory.as_fd())?,
         ExtendedAclPresence::Present,
         "a read-only child-directory descriptor must observe its inherited ACL"
-    );
-
-    let _inverse_creator = File::create_new(&inverse_original_path)?;
-    let inverse_retained = File::open(&inverse_original_path)?;
-    std::fs::rename(&inverse_original_path, &inverse_retained_path)?;
-    let _inverse_replacement_creator = File::create_new(&inverse_original_path)?;
-    let inverse_replacement = File::open(&inverse_original_path)?;
-    let inverse_allow = AclEntry::allow_user(&principal, Perm::READ, None::<Flag>);
-    setfacl(
-        &[&inverse_original_path],
-        &[inverse_allow],
-        None::<AclOption>,
-    )?;
-    assert_eq!(
-        extended_acl_presence(inverse_retained.as_fd())?,
-        ExtendedAclPresence::Absent,
-        "an ACL-bearing replacement must not alter the retained original descriptor"
-    );
-    assert_eq!(
-        extended_acl_presence(inverse_replacement.as_fd())?,
-        ExtendedAclPresence::Present,
-        "the ACL-bearing read-only replacement descriptor must report Present"
     );
     Ok(())
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -5,9 +5,163 @@ use exacl::{AclEntry, AclOption, Perm, getfacl, setfacl};
 use log::debug;
 use std::io;
 
+#[cfg(target_os = "macos")]
+use exacl::{ExtendedAclPresence, Flag, extended_acl_presence};
+#[cfg(target_os = "macos")]
+use std::fs::File;
+#[cfg(target_os = "macos")]
+use std::os::fd::AsFd;
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use std::time::{SystemTime, UNIX_EPOCH};
+
 #[ctor]
 fn init() {
     env_logger::init();
+}
+
+#[cfg(target_os = "macos")]
+fn persistent_acl_fixture(label: &str) -> PathBuf {
+    let timestamp_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should follow the Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "exacl-fd-presence-{}-{timestamp_nanos}-{label}",
+        std::process::id()
+    ))
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+#[ignore = "physical macOS ACL receipt; retains its unique fixtures for inspection"]
+fn physical_extended_acl_presence_is_bound_to_the_retained_fd() -> io::Result<()> {
+    let principal = std::env::var("USER").map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("USER must identify an ACL principal: {error}"),
+        )
+    })?;
+    let original_path = persistent_acl_fixture("original");
+    let retained_path = persistent_acl_fixture("retained");
+    let inverse_original_path = persistent_acl_fixture("inverse-original");
+    let inverse_retained_path = persistent_acl_fixture("inverse-retained");
+    let inherited_dir = persistent_acl_fixture("inherited-dir");
+    let inherited_child = inherited_dir.join("child");
+    let inherited_child_dir = inherited_dir.join("child-dir");
+
+    eprintln!(
+        "physical ACL receipt platform: os={} arch={}",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    );
+    eprintln!(
+        "retained physical ACL fixtures: {}, {}, {}, {}, {}",
+        original_path.display(),
+        retained_path.display(),
+        inverse_original_path.display(),
+        inverse_retained_path.display(),
+        inherited_dir.display()
+    );
+
+    let _original_creator = File::create_new(&original_path)?;
+    let retained = File::open(&original_path)?;
+    assert_eq!(
+        extended_acl_presence(retained.as_fd())?,
+        ExtendedAclPresence::Absent,
+        "a clean read-only regular-file descriptor must report Absent"
+    );
+
+    let allow = AclEntry::allow_user(&principal, Perm::READ, None::<Flag>);
+    setfacl(&[&original_path], std::slice::from_ref(&allow), None)?;
+    assert_eq!(
+        extended_acl_presence(retained.as_fd())?,
+        ExtendedAclPresence::Present,
+        "an ALLOW ACL must report Present through the retained read-only descriptor"
+    );
+    retained.metadata()?;
+
+    let deny = AclEntry::deny_user(&principal, Perm::WRITE, None::<Flag>);
+    setfacl(&[&original_path], &[deny], None)?;
+    assert_eq!(
+        extended_acl_presence(retained.as_fd())?,
+        ExtendedAclPresence::Present,
+        "a DENY ACL must report Present through the retained read-only descriptor"
+    );
+
+    setfacl(&[&original_path], &[], None)?;
+    assert_eq!(
+        extended_acl_presence(retained.as_fd())?,
+        ExtendedAclPresence::Absent,
+        "clearing the ACL must return the retained descriptor to Absent"
+    );
+
+    setfacl(&[&original_path], &[allow], None)?;
+    std::fs::rename(&original_path, &retained_path)?;
+    let _replacement_creator = File::create_new(&original_path)?;
+    let replacement = File::open(&original_path)?;
+    assert_eq!(
+        extended_acl_presence(retained.as_fd())?,
+        ExtendedAclPresence::Present,
+        "the retained descriptor must not follow a replacement at its old pathname"
+    );
+    assert_eq!(
+        extended_acl_presence(replacement.as_fd())?,
+        ExtendedAclPresence::Absent,
+        "the read-only replacement descriptor must remain ACL-free"
+    );
+
+    std::fs::create_dir(&inherited_dir)?;
+    let clean_directory = File::open(&inherited_dir)?;
+    assert_eq!(
+        extended_acl_presence(clean_directory.as_fd())?,
+        ExtendedAclPresence::Absent,
+        "a clean read-only directory descriptor must report Absent"
+    );
+    let inheritable = AclEntry::allow_user(
+        &principal,
+        Perm::READ,
+        Flag::FILE_INHERIT | Flag::DIRECTORY_INHERIT,
+    );
+    setfacl(&[&inherited_dir], &[inheritable], None)?;
+    let _child_creator = File::create_new(&inherited_child)?;
+    let child = File::open(&inherited_child)?;
+    assert_eq!(
+        extended_acl_presence(child.as_fd())?,
+        ExtendedAclPresence::Present,
+        "a read-only child-file descriptor must observe its inherited ACL"
+    );
+    std::fs::create_dir(&inherited_child_dir)?;
+    let child_directory = File::open(&inherited_child_dir)?;
+    assert_eq!(
+        extended_acl_presence(child_directory.as_fd())?,
+        ExtendedAclPresence::Present,
+        "a read-only child-directory descriptor must observe its inherited ACL"
+    );
+
+    let _inverse_creator = File::create_new(&inverse_original_path)?;
+    let inverse_retained = File::open(&inverse_original_path)?;
+    std::fs::rename(&inverse_original_path, &inverse_retained_path)?;
+    let _inverse_replacement_creator = File::create_new(&inverse_original_path)?;
+    let inverse_replacement = File::open(&inverse_original_path)?;
+    let inverse_allow = AclEntry::allow_user(&principal, Perm::READ, None::<Flag>);
+    setfacl(
+        &[&inverse_original_path],
+        &[inverse_allow],
+        None::<AclOption>,
+    )?;
+    assert_eq!(
+        extended_acl_presence(inverse_retained.as_fd())?,
+        ExtendedAclPresence::Absent,
+        "an ACL-bearing replacement must not alter the retained original descriptor"
+    );
+    assert_eq!(
+        extended_acl_presence(inverse_replacement.as_fd())?,
+        ExtendedAclPresence::Present,
+        "the ACL-bearing read-only replacement descriptor must report Present"
+    );
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `ExtendedAclPresence` and `extended_acl_presence(BorrowedFd)` on macOS
- query the retained descriptor directly with `acl_get_fd_np(ACL_TYPE_EXTENDED)`
- map only null plus `ENOENT` to `Absent`; return every other native failure as `io::Error`
- treat every non-null ACL as `Present` only after exactly one successful `acl_free`
- add no dependencies and preserve the Rust 1.85 MSRV

## Motivation

The existing high-level API is pathname based. Security-sensitive consumers that already hold an admitted descriptor need to inspect that exact object without pathname or `/dev/fd` re-resolution. This deliberately exposes only presence, not raw ACL storage or decoded entries.

## Safety

The public boundary takes `BorrowedFd`, so ownership does not transfer and the descriptor cannot escape the borrow. Unsafe calls remain private to the existing macOS backend. The getter result is never dereferenced; null results are never freed; each non-null native allocation is freed exactly once and never used afterward. Errno is captured immediately after failed native calls, and free failure is not retried.

## Tests

- injected null/error/free matrix, including `ENOENT`, `EBADF`, `EINVAL`, `ENOMEM`, `EOPNOTSUPP`, `ENOTSUP`, errno zero, no-free-on-null, exactly-one-free, and no errno read on success
- ignored physical macOS receipt covering clean, ALLOW, DENY, clear, read-only file and directory descriptors, inherited child file and directory ACLs, and both pathname-substitution directions
- Linux Rust 1.85 all-features tests/check/clippy/docs and package verification
- Apple M4 Pro/macOS 26.2 Rust 1.85 native tests and clippy
- `x86_64-apple-darwin` Rust 1.85 cross-target all-targets/all-features check

The physical test intentionally retains uniquely named fixtures and logs their paths for post-failure inspection.