### PR TITLE
Add support for _LABTEST feature to verify expected behavior on systems that have weird user name mappings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
       run: |
         export DEBIAN_FRONTEND=noninteractive
         apt-get update
-        apt-get -y install curl build-essential libacl1-dev acl shunit2 shellcheck
+        # Need `libclang-dev` for bindgen.
+        apt-get -y install curl build-essential libacl1-dev libclang-dev acl shunit2 shellcheck
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - name: Fetch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,9 @@ jobs:
         persist-credentials: false
     - name: Install dependencies (Linux)
       run: |
+        export DEBIAN_FRONTEND=noninteractive
         apt-get update
-        apt-get -y install curl build-essential libacl1-dev libclang-dev acl shunit2 shellcheck
+        apt-get -y install curl build-essential libacl1-dev acl shunit2 shellcheck
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - name: Fetch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,11 +171,11 @@ jobs:
           # Run tests on our mem-based FS with acls.
           export TMPDIR=/tmp/exacl_acls
           echo "*** TMPDIR=$TMPDIR"
-          RUST_LOG=debug cargo test --features serde
+          RUST_LOG=debug cargo test --features serde,_LABTEST
           ./tests/run_tests.sh
           export TMPDIR=/tmp/exacl_nfsv4acls
           echo "*** TMPDIR=$TMPDIR"
-          cargo test --features serde
+          RUST_LOG=debug cargo test --features serde,_LABTEST
           ./tests/run_tests.sh
           export TMPDIR=/tmp
           echo "*** TMPDIR=$TMPDIR"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Unit Test (no-serde)
       run: RUST_LOG=debug cargo test
     - name: Unit Test (serde)
-      run: RUST_LOG=debug cargo test --features serde
+      run: RUST_LOG=debug cargo test --features serde,_LABTEST
     - name: Run integration tests
       run: ./tests/run_tests.sh
     - name: Run memory tests
@@ -109,7 +109,7 @@ jobs:
     - name: Unit Test (no-serde)
       run: RUST_LOG=debug cargo test
     - name: Unit Test (serde)
-      run: RUST_LOG=debug cargo test --features serde
+      run: RUST_LOG=debug cargo test --features serde,_LABTEST
     - name: Run integration tests
       run:  setpriv --reuid=1001 --regid=1001 --clear-groups ./tests/run_tests.sh
     - name: Lint Check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ default = []
 
 buildtime_bindgen = ["bindgen"]
 
+# The _LABTEST feature is used to mock weird name/uid environments for testing.
+# This feature does not compile in --release mode.
+
+_LABTEST = []
+
 [dependencies]
 bitflags = "2.11.1"
 log = "0.4.29"

--- a/examples/exacl.rs
+++ b/examples/exacl.rs
@@ -6,12 +6,17 @@
 //! To set the ACL for myfile from JSON passed via stdin (complete replacement):
 //!     exacl --set myfile
 //!
+//! To set the ACL for myfile from JSON passed via command-line argument:
+//!     exacl --set --acl "[...]" myfile
+//!
 //! To get/set the ACL of a symlink itself, instead of the file it points to,
 //! use the -s option.
 //!
 //! To get/set the default ACL (on Linux), use the -d option.
 //!
 //! To get the ACL without translating uid/gid's to names, use the -n option.
+//!
+//! To use the delimited text format instead of JSON, use the `-f std` option.
 
 use exacl::{AclEntry, AclOption, getfacl, setfacl};
 use std::io;
@@ -24,7 +29,7 @@ use clap::Parser;
 #[command(name = "exacl", about = "Read or write a file's ACL.")]
 #[allow(clippy::struct_excessive_bools)]
 struct Opt {
-    /// Set file's ACL.
+    /// Set file's ACL from STDIN or `--acl` arguments.
     #[arg(long)]
     set: bool,
 
@@ -43,6 +48,10 @@ struct Opt {
     /// Get ACL as numeric only.
     #[arg(short = 'n', long)]
     numeric: bool,
+
+    /// Set ACL to specified value (may combine multiple ACL's).
+    #[arg(long)]
+    acl: Vec<String>,
 
     /// Format of input or output.
     #[arg(value_enum, short = 'f', long, default_value = "json")]
@@ -83,7 +92,10 @@ fn main() {
     }
 
     let exit_code = if opt.set {
-        set_acl(&opt.files, options, opt.format)
+        set_acl(&opt.files, options, opt.format, &opt.acl)
+    } else if !opt.acl.is_empty() {
+        eprintln!("Use of --acl requires --set");
+        EXIT_FAILURE
     } else {
         get_acl(&opt.files, options, opt.format)
     };
@@ -102,8 +114,8 @@ fn get_acl(paths: &[PathBuf], options: AclOption, format: Format) -> i32 {
     EXIT_SUCCESS
 }
 
-fn set_acl(paths: &[PathBuf], options: AclOption, format: Format) -> i32 {
-    let Some(entries) = read_input(format) else {
+fn set_acl(paths: &[PathBuf], options: AclOption, format: Format, acls: &[String]) -> i32 {
+    let Some(entries) = read_acl_input(format, acls) else {
         return EXIT_FAILURE;
     };
 
@@ -134,8 +146,31 @@ fn dump_acl(path: &Path, options: AclOption, format: Format) -> io::Result<()> {
     Ok(())
 }
 
-fn read_input(format: Format) -> Option<Vec<AclEntry>> {
-    let reader = io::BufReader::new(io::stdin());
+fn read_acl_input(format: Format, acls: &[String]) -> Option<Vec<AclEntry>> {
+    if acls.is_empty() {
+        // Read one ACL from stdin.
+        let Some(entries) = read_input(io::stdin(), format) else {
+            return None;
+        };
+        Some(entries)
+    } else {
+        // Read multiple ACLs and combine them.
+        let mut entries = vec![];
+        for acl in acls {
+            let Some(ents) = read_input(acl.as_bytes(), format) else {
+                return None;
+            };
+            entries.extend_from_slice(&ents);
+        }
+        Some(entries)
+    }
+}
+
+fn read_input<R>(source: R, format: Format) -> Option<Vec<AclEntry>>
+where
+    R: io::Read,
+{
+    let reader = io::BufReader::new(source);
 
     let entries: Vec<AclEntry> = match format {
         // Read JSON format.

--- a/examples/exacl.rs
+++ b/examples/exacl.rs
@@ -149,17 +149,12 @@ fn dump_acl(path: &Path, options: AclOption, format: Format) -> io::Result<()> {
 fn read_acl_input(format: Format, acls: &[String]) -> Option<Vec<AclEntry>> {
     if acls.is_empty() {
         // Read one ACL from stdin.
-        let Some(entries) = read_input(io::stdin(), format) else {
-            return None;
-        };
-        Some(entries)
+        read_input(io::stdin(), format)
     } else {
         // Read multiple ACLs and combine them.
         let mut entries = vec![];
         for acl in acls {
-            let Some(ents) = read_input(acl.as_bytes(), format) else {
-                return None;
-            };
+            let ents = read_input(acl.as_bytes(), format)?;
             entries.extend_from_slice(&ents);
         }
         Some(entries)

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -52,10 +52,15 @@ bitflags! {
 
 impl Flag {
     // On FreeBSD, acl_flag_t is a u16. On Linux and macOS, acl_flag_t is a u32.
-    // To appease the linter, provide a helper function to cast Flag to u32.
+    // To appease the linter, provide helper functions to cast Flag to/from u32.
     const fn as_u32(self) -> u32 {
         #[allow(clippy::unnecessary_cast)]
         return self.bits() as u32;
+    }
+
+    const fn from_u32(bits: u32) -> Flag {
+        #[allow(clippy::cast_possible_truncation)]
+        Flag::from_bits_retain(bits as acl_flag_t)
     }
 }
 
@@ -65,7 +70,7 @@ impl BitIterable for Flag {
             return None;
         }
         let low_bit = 1u32 << self.bits().trailing_zeros();
-        Some(Flag::from_bits_retain(low_bit as acl_flag_t))
+        Some(Flag::from_u32(low_bit))
     }
 
     fn msb(self) -> Option<Self> {
@@ -77,7 +82,7 @@ impl BitIterable for Flag {
             return None;
         }
         let high_bit = 1u32 << (MAX_BITS - self.bits().leading_zeros());
-        Some(Flag::from_bits_retain(high_bit as acl_flag_t))
+        Some(Flag::from_u32(high_bit))
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -88,25 +88,25 @@ fn getpwnam(name: &str) -> io::Result<Option<uid_t>> {
 
     if result.is_null() {
         #[cfg(feature = "_LABTEST")]
-        return labtest_mock_getpwnam(name);
+        return Ok(labtest_mock_getpwnam(name));
 
-        Ok(None)
-    } else {
-        let uid = unsafe { pwd.assume_init().pw_uid };
-        Ok(Some(uid))
+        #[cfg(not(feature = "_LABTEST"))]
+        return Ok(None);
     }
+
+    let uid = unsafe { pwd.assume_init().pw_uid };
+    Ok(Some(uid))
 }
 
 /// Mock additional name -> uid mappings for _LABTEST.
 #[cfg(all(debug_assertions, feature = "_LABTEST"))]
-fn labtest_mock_getpwnam(name: &str) -> io::Result<Option<uid_t>> {
-    let result = match name {
-        "\u{1F9EA}" => Some(777771),
-        "777772" => Some(777773),
-        "fbbc14b7-95f9-47a7-8ee8-1cccb9220943" => Some(777774),
+fn labtest_mock_getpwnam(name: &str) -> Option<uid_t> {
+    match name {
+        "\u{1F9EA}" => Some(777_771),
+        "777772" => Some(777_773),
+        "fbbc14b7-95f9-47a7-8ee8-1cccb9220943" => Some(777_774),
         _ => None,
-    };
-    Ok(result)
+    }
 }
 
 /// Convert group name to gid.
@@ -204,25 +204,25 @@ fn getpwuid(uid: uid_t) -> io::Result<Option<String>> {
 
     if result.is_null() {
         #[cfg(feature = "_LABTEST")]
-        return labtest_mock_getpwuid(uid);
+        return Ok(labtest_mock_getpwuid(uid));
 
-        Ok(None)
-    } else {
-        let cstr = unsafe { CStr::from_ptr(pwd.assume_init().pw_name) };
-        Ok(Some(cstr.to_string_lossy().into_owned()))
+        #[cfg(not(feature = "_LABTEST"))]
+        return Ok(None);
     }
+
+    let cstr = unsafe { CStr::from_ptr(pwd.assume_init().pw_name) };
+    Ok(Some(cstr.to_string_lossy().into_owned()))
 }
 
 /// Mock additional uid -> name mappings for _LABTEST.
 #[cfg(all(debug_assertions, feature = "_LABTEST"))]
-fn labtest_mock_getpwuid(uid: uid_t) -> io::Result<Option<String>> {
-    let result = match uid {
-        777771 => Some("\u{1F9EA}".into()),
-        777773 => Some("777772".into()),
-        777774 => Some("fbbc14b7-95f9-47a7-8ee8-1cccb9220943".into()),
+fn labtest_mock_getpwuid(uid: uid_t) -> Option<String> {
+    match uid {
+        777_771 => Some("\u{1F9EA}".into()),
+        777_773 => Some("777772".into()),
+        777_774 => Some("fbbc14b7-95f9-47a7-8ee8-1cccb9220943".into()),
         _ => None,
-    };
-    Ok(result)
+    }
 }
 
 /// Convert gid to group name.
@@ -718,9 +718,9 @@ mod tests {
         helper::init_logging();
 
         let users = [
-            ("\u{1F9EA}", 777771),
-            ("777772", 777773),
-            ("fbbc14b7-95f9-47a7-8ee8-1cccb9220943", 777774),
+            ("\u{1F9EA}", 777_771),
+            ("777772", 777_773),
+            ("fbbc14b7-95f9-47a7-8ee8-1cccb9220943", 777_774),
         ];
 
         for (name, uid) in users {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,4 +1,17 @@
 //! Implements utilities for converting user/group names to uid/gid.
+//
+// This module supports a `_LABTEST` feature that adds the following
+// name/uid mappings. These are designed to catch some edge cases in testing.
+// To use the _LABTEST feature, code has to be explicitly compiled by cargo in
+// debug mode with the _LABTEST feature enabled. You can detect code is
+// compiled with _LABTEST by using the 🧪 emoji as a user name.
+//
+//   NAME                                     UID
+//   ----                                     ------
+//   "\u{1F9EA}"  (test tube emoji)           777771
+//   "777772"                                 777773
+//   "fbbc14b7-95f9-47a7-8ee8-1cccb9220943"   777774
+//
 
 use crate::failx::*;
 use crate::sys::{getgrgid_r, getgrnam_r, getpwnam_r, getpwuid_r, group, passwd, sg};
@@ -20,7 +33,7 @@ pub use crate::sys::{gid_t, uid_t};
 // by calling sysconf with SC_GETPW_R_SIZE_MAX or SC_GETGR_R_SIZE_MAX. Rather
 // than calling sysconf, this code hard-wires the default value and quadruples
 // the buffer size as needed, up to a maximum of 1MB.
-
+//
 // SC_GETPW_R_SIZE_MAX/SC_GETGR_R_SIZE_MAX default to 1024 on vanilla Ubuntu
 // and 4096 on macOS/FreeBSD. We start the initial buffer size at 4096 bytes.
 
@@ -74,11 +87,26 @@ fn getpwnam(name: &str) -> io::Result<Option<uid_t>> {
     }
 
     if result.is_null() {
+        #[cfg(feature = "_LABTEST")]
+        return labtest_mock_getpwnam(name);
+
         Ok(None)
     } else {
         let uid = unsafe { pwd.assume_init().pw_uid };
         Ok(Some(uid))
     }
+}
+
+/// Mock additional name -> uid mappings for _LABTEST.
+#[cfg(all(debug_assertions, feature = "_LABTEST"))]
+fn labtest_mock_getpwnam(name: &str) -> io::Result<Option<uid_t>> {
+    let result = match name {
+        "\u{1F9EA}" => Some(777771),
+        "777772" => Some(777773),
+        "fbbc14b7-95f9-47a7-8ee8-1cccb9220943" => Some(777774),
+        _ => None,
+    };
+    Ok(result)
 }
 
 /// Convert group name to gid.
@@ -175,11 +203,26 @@ fn getpwuid(uid: uid_t) -> io::Result<Option<String>> {
     }
 
     if result.is_null() {
+        #[cfg(feature = "_LABTEST")]
+        return labtest_mock_getpwuid(uid);
+
         Ok(None)
     } else {
         let cstr = unsafe { CStr::from_ptr(pwd.assume_init().pw_name) };
         Ok(Some(cstr.to_string_lossy().into_owned()))
     }
+}
+
+/// Mock additional uid -> name mappings for _LABTEST.
+#[cfg(all(debug_assertions, feature = "_LABTEST"))]
+fn labtest_mock_getpwuid(uid: uid_t) -> io::Result<Option<String>> {
+    let result = match uid {
+        777771 => Some("\u{1F9EA}".into()),
+        777773 => Some("777772".into()),
+        777774 => Some("fbbc14b7-95f9-47a7-8ee8-1cccb9220943".into()),
+        _ => None,
+    };
+    Ok(result)
 }
 
 /// Convert gid to group name.
@@ -655,12 +698,37 @@ mod tests {
             ),
             ("ffffeeee-dddd-cccc-bbbb-aaaa00000000", (Some(0), None)),
             ("abcdefab-cdef-abcd-efab-cdef00000000", (None, Some(0))),
+            ("ffffeeeeddddccccbbbbaaaa000005dc", (Some(1500), None)),
+            ("abcdefabcdefabcdefabcdef00000000", (None, Some(0))),
         ];
 
         for (uuid, expected) in uuids {
             let guid = Uuid::parse_str(uuid)?;
             let id = guid_to_id(guid)?;
             assert_eq!(id, expected);
+        }
+
+        Ok(())
+    }
+
+    /// Test the `_LABTEST` feature.
+    #[test]
+    #[cfg(feature = "_LABTEST")]
+    fn test_labtest() -> TestResult {
+        helper::init_logging();
+
+        let users = [
+            ("\u{1F9EA}", 777771),
+            ("777772", 777773),
+            ("fbbc14b7-95f9-47a7-8ee8-1cccb9220943", 777774),
+        ];
+
+        for (name, uid) in users {
+            let result = getpwnam(name)?;
+            assert_eq!(result, Some(uid));
+
+            let result = getpwuid(uid)?;
+            assert_eq!(result, Some(name.into()));
         }
 
         Ok(())

--- a/tests/testsuite_darwin.sh
+++ b/tests/testsuite_darwin.sh
@@ -628,5 +628,119 @@ testDuplicateEntry() {
         "${msg//\`/}"
 }
 
+testWriteAclToFile1_LabTest() {
+    # Set ACL for 🧪 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:🧪,perms:[read],flags:[],allow:false}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777772 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:777772,perms:[read],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777772,perms:[read],flags:[],allow:false}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777773 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:777773,perms:[read],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL (note assymetry).
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777772,perms:[read],flags:[],allow:false}]" \
+        "${msg//\"/}"
+
+    # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:false}]" \
+        "${msg//\"/}"
+}
+
+testWriteAclToFile1_LabTestNumeric() {
+    # Set ACL for 🧪 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777771,perms:[read],flags:[],allow:false}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777772 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:777772,perms:[read],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL (note assymetry).
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777773,perms:[read],flags:[],allow:false}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777773 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:777773,perms:[read],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777773,perms:[read],flags:[],allow:false}]" \
+        "${msg//\"/}"
+
+    # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777774,perms:[read],flags:[],allow:false}]" \
+        "${msg//\"/}"
+}
+
 # shellcheck disable=SC1091
 . shunit2

--- a/tests/testsuite_darwin.sh
+++ b/tests/testsuite_darwin.sh
@@ -708,7 +708,7 @@ testWriteAclToFile1_LabTestNumeric() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Read ACL (note assymetry).
+    # Read ACL (note asymmetry).
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \

--- a/tests/testsuite_freebsd_acls.sh
+++ b/tests/testsuite_freebsd_acls.sh
@@ -652,8 +652,7 @@ testWriteAclToFile1_LabTest() {
     msg=$($EXACL $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:tru
-e}]" \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
         "${msg//\"/}"
 }
 

--- a/tests/testsuite_freebsd_acls.sh
+++ b/tests/testsuite_freebsd_acls.sh
@@ -641,13 +641,13 @@ testWriteAclToFile1_LabTest() {
     assertEquals \
         "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777772,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
         "${msg//\"/}"
-    
+
     # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "allow read".
     input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true}]")
     msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
     assertEquals 0 $?
     assertEquals "" "$msg"
-    
+
     # Read ACL.
     msg=$($EXACL $FILE1)
     assertEquals 0 $?
@@ -660,7 +660,7 @@ e}]" \
 testWriteAclToFile1_LabTestNumeric() {
     # The 3 required entries for Linux.
     required=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
- 
+
     # Set ACL for 🧪 to "allow read".
     input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read],flags:[],allow:true}]")
     msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
@@ -669,7 +669,7 @@ testWriteAclToFile1_LabTestNumeric() {
         return 0
     fi
     assertEquals "" "$msg"
- 
+
     # Read ACL.
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?

--- a/tests/testsuite_freebsd_acls.sh
+++ b/tests/testsuite_freebsd_acls.sh
@@ -596,5 +596,126 @@ testDuplicateEntry() {
         "${msg//\`/}"
 }
 
+testWriteAclToFile1_LabTest() {
+    # The 3 required entries for Linux.
+    required=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
+
+    # Set ACL for 🧪 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:🧪,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777772 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777772,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777772,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777773 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777773,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL (note asymmetry).
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777772,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+    
+    # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+    
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:tru
+e}]" \
+        "${msg//\"/}"
+}
+
+testWriteAclToFile1_LabTestNumeric() {
+    # The 3 required entries for Linux.
+    required=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
+ 
+    # Set ACL for 🧪 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+ 
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777771,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777772 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777772,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL (note asymmetry).
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777773,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777773 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777773,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777773,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777774,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+}
+
 # shellcheck disable=SC1091
 . shunit2

--- a/tests/testsuite_freebsd_nfsv4acls.sh
+++ b/tests/testsuite_freebsd_nfsv4acls.sh
@@ -709,14 +709,14 @@ testWriteAclToFile1_LabTest() {
         return 0
     fi
     assertEquals "" "$msg"
-    
+
     # Read ACL.
     msg=$($EXACL $FILE1)
     assertEquals 0 $?
     assertEquals \
         "[{kind:user,name:🧪,perms:[read_data],flags:[],allow:false}]" \
         "${msg//\"/}"
-    
+
     # Set ACL for 777772 to "deny read".
     input=$(quotifyJson "[{kind:user,name:777772,perms:[read_data],flags:[],allow:false}]")
     msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
@@ -742,18 +742,18 @@ testWriteAclToFile1_LabTest() {
     assertEquals \
         "[{kind:user,name:777772,perms:[read_data],flags:[],allow:false}]" \
         "${msg//\"/}"
-    
+
     # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "deny read".
     input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read_data],flags:[],allow:false}]")
     msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
     assertEquals 0 $?
     assertEquals "" "$msg"
-    
+
     # Read ACL.
     msg=$($EXACL $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read_data],flags:[],allow:false}]"\
+        "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read_data],flags:[],allow:false}]" \
         "${msg//\"/}"
 }
 
@@ -766,14 +766,14 @@ testWriteAclToFile1_LabTestNumeric() {
         return 0
     fi
     assertEquals "" "$msg"
-    
+
     # Read ACL.
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
         "[{kind:user,name:777771,perms:[read_data],flags:[],allow:false}]" \
         "${msg//\"/}"
-    
+
     # Set ACL for 777772 to "deny read".
     input=$(quotifyJson "[{kind:user,name:777772,perms:[read_data],flags:[],allow:false}]")
     msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
@@ -799,18 +799,18 @@ testWriteAclToFile1_LabTestNumeric() {
     assertEquals \
         "[{kind:user,name:777773,perms:[read_data],flags:[],allow:false}]" \
         "${msg//\"/}"
-    
+
     # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "deny read".
     input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read_data],flags:[],allow:false}]")
     msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
     assertEquals 0 $?
     assertEquals "" "$msg"
-    
+
     # Read ACL.
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:777774,perms:[read_data],flags:[],allow:false}]"\
+        "[{kind:user,name:777774,perms:[read_data],flags:[],allow:false}]" \
         "${msg//\"/}"
 }
 

--- a/tests/testsuite_freebsd_nfsv4acls.sh
+++ b/tests/testsuite_freebsd_nfsv4acls.sh
@@ -700,5 +700,119 @@ group@:--------------:-------:deny" \
         "${msg}"
 }
 
+testWriteAclToFile1_LabTest() {
+    # Set ACL for 🧪 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read_data],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+    
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:🧪,perms:[read_data],flags:[],allow:false}]" \
+        "${msg//\"/}"
+    
+    # Set ACL for 777772 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:777772,perms:[read_data],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777772,perms:[read_data],flags:[],allow:false}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777773 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777773,perms:[read_data],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL (note asymmetry).
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777772,perms:[read_data],flags:[],allow:false}]" \
+        "${msg//\"/}"
+    
+    # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read_data],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+    
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read_data],flags:[],allow:false}]"\
+        "${msg//\"/}"
+}
+
+testWriteAclToFile1_LabTestNumeric() {
+    # Set ACL for 🧪 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read_data],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+    
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777771,perms:[read_data],flags:[],allow:false}]" \
+        "${msg//\"/}"
+    
+    # Set ACL for 777772 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:777772,perms:[read_data],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL. (note asymmetry)
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777773,perms:[read_data],flags:[],allow:false}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777773 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777773,perms:[read_data],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777773,perms:[read_data],flags:[],allow:false}]" \
+        "${msg//\"/}"
+    
+    # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "deny read".
+    input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read_data],flags:[],allow:false}]")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+    
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:777774,perms:[read_data],flags:[],allow:false}]"\
+        "${msg//\"/}"
+}
+
 # shellcheck disable=SC1091
 . shunit2

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -696,5 +696,125 @@ testDuplicateEntry() {
         "${msg//\`/}"
 }
 
+testWriteAclToFile1_LabTest() {
+    # The 3 required entries for Linux.
+    required=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
+
+    # Set ACL for 🧪 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:🧪,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777772 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777772,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777772,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777773 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777773,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL (note asymmetry).
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777772,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+}
+
+testWriteAclToFile1_LabTestNumeric() {
+    # The 3 required entries for Linux.
+    required=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
+
+    # Set ACL for 🧪 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777771,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777772 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777772,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL (note asymmetry).
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777773,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for 777773 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:777773,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777773,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+
+    # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "allow read".
+    input=$(quotifyJson "[{kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true}]")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Read ACL.
+    msg=$($EXACL -n $FILE1)
+    assertEquals 0 $?
+    assertEquals \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777774,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "${msg//\"/}"
+}
+
 # shellcheck disable=SC1091
 . shunit2

--- a/tests/testsuite_malformed_all.sh
+++ b/tests/testsuite_malformed_all.sh
@@ -240,5 +240,13 @@ testInvalidStdFormat() {
         "${msg//\`/}"
 }
 
+testInvalidStdFormatUsingArg() {
+    msg=$($EXACL -f std --set --acl "group:a:read" --acl "user:x" non_existant 2>&1)
+    assertEquals 1 $?
+    assertEquals \
+        "Std parser error: Unknown ACL format: user:x" \
+        "${msg//\`/}"
+}
+
 # shellcheck disable=SC1091
 . shunit2


### PR DESCRIPTION
- The example program now supports an --acl argument to make writing tests easier.