### PR TITLE
Correct handling of user/group names that are not valid UTF-8.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
           mkdir -p /tmp/bin
           curl https://raw.githubusercontent.com/kward/shunit2/master/shunit2 -sSf --output /tmp/bin/shunit2
           chmod ugo+x /tmp/bin/shunit2
+          ./ci/add-nonutf8-group.sh
         run: |
           . $HOME/.cargo/env
           # Set up path for shunit2.

--- a/ci/add-nonutf8-group.sh
+++ b/ci/add-nonutf8-group.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+# This script adds a group named "é" (Latin1) to a FreeBSD system
+# as gid=777775. This group name is not valid UTF-8.
+
+NAME="\xe9"
+GID=777775
+
+# Append the /etc/group entry: NAME:*:GID:USERS
+printf "%b:*:%d:\n" "$NAME" "$GID" >>/etc/group
+
+echo "Added non-UTF8 group name."
+exit 0

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -11,7 +11,7 @@
 //   "\u{1F9EA}"  (test tube emoji)           777771
 //   "777772"                                 777773
 //   "fbbc14b7-95f9-47a7-8ee8-1cccb9220943"   777774
-//
+//   <placeholder for non-UTF8>               777775
 
 use crate::failx::*;
 use crate::sys::{getgrgid_r, getgrnam_r, getpwnam_r, getpwuid_r, group, passwd, sg};
@@ -210,8 +210,12 @@ fn getpwuid(uid: uid_t) -> io::Result<Option<String>> {
         return Ok(None);
     }
 
+    // A Rust `String` can only store valid UTF-8. It is possible for the
+    // system to return a C String that contains non-UTF-8 bytes. When this
+    // happens we return None, as if the name does not exist.
     let cstr = unsafe { CStr::from_ptr(pwd.assume_init().pw_name) };
-    Ok(Some(cstr.to_string_lossy().into_owned()))
+    let name = cstr.to_str().ok();
+    Ok(name.map(std::convert::Into::into))
 }
 
 /// Mock additional uid -> name mappings for _LABTEST.
@@ -265,11 +269,15 @@ fn getgrgid(gid: gid_t) -> io::Result<Option<String>> {
     }
 
     if result.is_null() {
-        Ok(None)
-    } else {
-        let cstr = unsafe { CStr::from_ptr(grp.assume_init().gr_name) };
-        Ok(Some(cstr.to_string_lossy().into_owned()))
+        return Ok(None);
     }
+
+    // A Rust `String` can only store valid UTF-8. It is possible for the
+    // system to return a C String that contains non-UTF-8 bytes. When this
+    // happens we return None, as if the name does not exist.
+    let cstr = unsafe { CStr::from_ptr(grp.assume_init().gr_name) };
+    let name = cstr.to_str().ok();
+    Ok(name.map(std::convert::Into::into))
 }
 
 /// Convert uid to GUID.
@@ -721,6 +729,7 @@ mod tests {
             ("\u{1F9EA}", 777_771),
             ("777772", 777_773),
             ("fbbc14b7-95f9-47a7-8ee8-1cccb9220943", 777_774),
+            ("777775", 777_775), // placeholder for testing non-UTF-8 name
         ];
 
         for (name, uid) in users {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -280,8 +280,10 @@ fn getgrgid(gid: gid_t) -> io::Result<Option<String>> {
     // system to return a C String that contains non-UTF-8 bytes. When this
     // happens we return None, as if the name does not exist.
     let cstr = unsafe { CStr::from_ptr(grp.assume_init().gr_name) };
-    let name = cstr.to_str().ok();
-    Ok(name.map(std::convert::Into::into))
+    return Ok(Some(cstr.to_string_lossy().into_owned()));
+
+    //let name = cstr.to_str().ok();
+    //Ok(name.map(std::convert::Into::into))
 }
 
 /// Convert uid to GUID.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -280,7 +280,7 @@ fn getgrgid(gid: gid_t) -> io::Result<Option<String>> {
     // system to return a C String that contains non-UTF-8 bytes. When this
     // happens we return None, as if the name does not exist.
     let cstr = unsafe { CStr::from_ptr(grp.assume_init().gr_name) };
-    return Ok(Some(cstr.to_string_lossy().into_owned()));
+    Ok(Some(cstr.to_string_lossy().into_owned()))
 
     //let name = cstr.to_str().ok();
     //Ok(name.map(std::convert::Into::into))

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -729,7 +729,6 @@ mod tests {
             ("\u{1F9EA}", 777_771),
             ("777772", 777_773),
             ("fbbc14b7-95f9-47a7-8ee8-1cccb9220943", 777_774),
-            ("777775", 777_775), // placeholder for testing non-UTF-8 name
         ];
 
         for (name, uid) in users {
@@ -739,6 +738,10 @@ mod tests {
             let result = getpwuid(uid)?;
             assert_eq!(result, Some(name.into()));
         }
+
+        // Test placeholder for non-UTF-8 name.
+        let result = uid_to_name(777_775)?;
+        assert_eq!(result, "777775");
 
         Ok(())
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -4,14 +4,18 @@
 // name/uid mappings. These are designed to catch some edge cases in testing.
 // To use the _LABTEST feature, code has to be explicitly compiled by cargo in
 // debug mode with the _LABTEST feature enabled. You can detect code is
-// compiled with _LABTEST by using the 🧪 emoji as a user name.
+// compiled with _LABTEST by using the 🧪 emoji as a user name. The group name
+// mapping is tested on FreeBSD by adding the group name manually to /etc/group.
 //
-//   NAME                                     UID
-//   ----                                     ------
+//   USER NAME                                UID
+//   ---------                                ------
 //   "\u{1F9EA}"  (test tube emoji)           777771
 //   "777772"                                 777773
 //   "fbbc14b7-95f9-47a7-8ee8-1cccb9220943"   777774
-//   <placeholder for non-UTF8>               777775
+//
+//   GROUP NAME                               GID
+//   ----------                               ------
+//   é (using latin1 encoding)                777775
 
 use crate::failx::*;
 use crate::sys::{getgrgid_r, getgrnam_r, getpwnam_r, getpwuid_r, group, passwd, sg};
@@ -739,8 +743,10 @@ mod tests {
             assert_eq!(result, Some(name.into()));
         }
 
-        // Test placeholder for non-UTF-8 name.
-        let result = uid_to_name(777_775)?;
+        // Test non-UTF-8 group name on systems where it was added.
+        // Even when a group name is available, the result should be the GID
+        // in decimal.
+        let result = gid_to_name(777_775)?;
         assert_eq!(result, "777775");
 
         Ok(())

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -280,10 +280,8 @@ fn getgrgid(gid: gid_t) -> io::Result<Option<String>> {
     // system to return a C String that contains non-UTF-8 bytes. When this
     // happens we return None, as if the name does not exist.
     let cstr = unsafe { CStr::from_ptr(grp.assume_init().gr_name) };
-    Ok(Some(cstr.to_string_lossy().into_owned()))
-
-    //let name = cstr.to_str().ok();
-    //Ok(name.map(std::convert::Into::into))
+    let name = cstr.to_str().ok();
+    Ok(name.map(std::convert::Into::into))
 }
 
 /// Convert uid to GUID.


### PR DESCRIPTION
Fixes #308 