### PR TITLE
Improve support for numeric/native ID's.

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -467,7 +467,7 @@ deny:file_inherit,directory_inherit:group:11504:read,write,execute
 
         // Test numeric option.
         let entries3 = acl2.entries(true)?;
-        assert_eq!(entries3[0].name, "89");
+        assert_eq!(entries3[0].name, "{abcdefab-cdef-abcd-efab-cdef00000059}");
 
         Ok(())
     }

--- a/src/aclentry.rs
+++ b/src/aclentry.rs
@@ -196,7 +196,7 @@ impl AclEntry {
     /// Return an `AclEntry` constructed from a native `acl_entry_t`.
     ///
     /// If `numeric` is true, retrieve numeric uid/gid instead of translating
-    /// names.
+    /// names. On macOS, `numeric` returns the GUID.
     pub(crate) fn from_raw(entry: acl_entry_t, acl: acl_t, numeric: bool) -> io::Result<AclEntry> {
         let (allow, qualifier, perms, flags) = xacl_get_entry(acl, entry)?;
 
@@ -208,6 +208,9 @@ impl AclEntry {
 
             #[cfg(target_os = "macos")]
             Qualifier::Group(_) => (AclEntryKind::Group, qualifier.name(numeric)?),
+
+            #[cfg(target_os = "macos")]
+            Qualifier::Guid(_) if numeric => (AclEntryKind::User, qualifier.name(true)?),
 
             #[cfg(target_os = "macos")]
             Qualifier::Guid(_) => {

--- a/src/qualifier.rs
+++ b/src/qualifier.rs
@@ -46,11 +46,7 @@ impl Qualifier {
     pub fn user_named(name: &str) -> io::Result<Qualifier> {
         match unix::name_to_uid(name) {
             Ok(uid) => Ok(Qualifier::User(uid)),
-            Err(err) => {
-                // Try to parse name as a GUID.
-                Uuid::parse_str(name)
-                    .map_or(Err(err), |guid| Qualifier::Guid(guid).translate_guid())
-            }
+            Err(err) => unix::name_to_guid(name).map_or(Err(err), Qualifier::from_guid),
         }
     }
 
@@ -71,8 +67,7 @@ impl Qualifier {
     pub fn group_named(name: &str) -> io::Result<Qualifier> {
         match unix::name_to_gid(name) {
             Ok(gid) => Ok(Qualifier::Group(gid)),
-            Err(err) => Uuid::parse_str(name)
-                .map_or(Err(err), |guid| Qualifier::Guid(guid).translate_guid()),
+            Err(err) => unix::name_to_guid(name).map_or(Err(err), Qualifier::from_guid),
         }
     }
 
@@ -115,6 +110,12 @@ impl Qualifier {
         }
     }
 
+    /// Create qualifier from GUID and translate it. Used internally.
+    #[cfg(target_os = "macos")]
+    fn from_guid(guid: Uuid) -> io::Result<Qualifier> {
+        Qualifier::Guid(guid).translate_guid()
+    }
+
     /// Return the GUID for the user/group.
     #[cfg(target_os = "macos")]
     pub fn guid(&self) -> io::Result<Uuid> {
@@ -146,7 +147,7 @@ impl Qualifier {
                 }
             }
             #[cfg(target_os = "macos")]
-            Qualifier::Guid(guid) => guid.to_string(),
+            Qualifier::Guid(guid) => guid.as_braced().to_string(),
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
             Qualifier::UserObj | Qualifier::GroupObj => OWNER_NAME.to_string(),
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -246,7 +247,7 @@ mod tests {
         // Test a user GUID on macOS.
         #[cfg(target_os = "macos")]
         {
-            let result = Qualifier::user_named("ffffeeee-dddd-cccc-bbbb-aaaa00000059")?;
+            let result = Qualifier::user_named("{ffffeeee-dddd-cccc-bbbb-aaaa00000059}")?;
             assert_eq!(result, Qualifier::User(89));
         }
 
@@ -268,7 +269,7 @@ mod tests {
         // Test a group GUID on macOS.
         #[cfg(target_os = "macos")]
         {
-            let result = Qualifier::group_named("abcdefab-cdef-abcd-efab-cdef00000059")?;
+            let result = Qualifier::group_named("{abcdefab-cdef-abcd-efab-cdef00000059}")?;
             assert_eq!(result, Qualifier::Group(89));
         }
 
@@ -295,8 +296,8 @@ mod tests {
             // Test `name` method on a Guid on macOS (numeric has no effect).
             let uuid = Uuid::parse_str("abcdefab-cdef-abcd-efab-cdef00000059")?;
             let guid = Qualifier::Guid(uuid);
-            assert_eq!(guid.name(false)?, "abcdefab-cdef-abcd-efab-cdef00000059");
-            assert_eq!(guid.name(true)?, "abcdefab-cdef-abcd-efab-cdef00000059");
+            assert_eq!(guid.name(false)?, "{abcdefab-cdef-abcd-efab-cdef00000059}");
+            assert_eq!(guid.name(true)?, "{abcdefab-cdef-abcd-efab-cdef00000059}");
         }
 
         Ok(())

--- a/src/qualifier.rs
+++ b/src/qualifier.rs
@@ -126,20 +126,10 @@ impl Qualifier {
     /// If `numeric` is true, return numeric uid/gid.
     pub fn name(&self, numeric: bool) -> io::Result<String> {
         let result = match self {
-            Qualifier::User(uid) => {
-                if numeric {
-                    uid.to_string()
-                } else {
-                    unix::uid_to_name(*uid)?
-                }
-            }
-            Qualifier::Group(gid) => {
-                if numeric {
-                    gid.to_string()
-                } else {
-                    unix::gid_to_name(*gid)?
-                }
-            }
+            Qualifier::User(uid) if numeric => uid.to_string(),
+            Qualifier::User(uid) => unix::uid_to_name(*uid)?,
+            Qualifier::Group(gid) if numeric => gid.to_string(),
+            Qualifier::Group(gid) => unix::gid_to_name(*gid)?,
             #[cfg(target_os = "macos")]
             Qualifier::Guid(guid) => guid.as_braced().to_string(),
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]

--- a/src/qualifier.rs
+++ b/src/qualifier.rs
@@ -55,10 +55,7 @@ impl Qualifier {
     pub fn user_named(name: &str) -> io::Result<Qualifier> {
         match name {
             OWNER_NAME => Ok(Qualifier::UserObj),
-            s => match unix::name_to_uid(s) {
-                Ok(uid) => Ok(Qualifier::User(uid)),
-                Err(err) => Err(err),
-            },
+            s => unix::name_to_uid(s).map(Qualifier::User),
         }
     }
 
@@ -76,10 +73,7 @@ impl Qualifier {
     pub fn group_named(name: &str) -> io::Result<Qualifier> {
         match name {
             OWNER_NAME => Ok(Qualifier::GroupObj),
-            s => match unix::name_to_gid(s) {
-                Ok(gid) => Ok(Qualifier::Group(gid)),
-                Err(err) => Err(err),
-            },
+            s => unix::name_to_gid(s).map(Qualifier::Group),
         }
     }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -672,7 +672,7 @@ mod tests {
 
         for (name, value) in test_cases {
             let guid = name_to_guid(name);
-            assert_eq!(guid, value, "name=`{}`", name);
+            assert_eq!(guid, value, "name=`{name}`");
         }
 
         Ok(())

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -15,7 +15,7 @@
 //
 //   GROUP NAME                               GID
 //   ----------                               ------
-//   é (using latin1 encoding)                777775
+//   é (non-UTF8 bytes; latin1 encoding)      777775
 
 use crate::failx::*;
 use crate::sys::{getgrgid_r, getgrnam_r, getpwnam_r, getpwuid_r, group, passwd, sg};
@@ -282,6 +282,18 @@ fn getgrgid(gid: gid_t) -> io::Result<Option<String>> {
     let cstr = unsafe { CStr::from_ptr(grp.assume_init().gr_name) };
     let name = cstr.to_str().ok();
     Ok(name.map(std::convert::Into::into))
+}
+
+/// Parse a user/group name as a UUID. The UUID must be in curly braces.
+/// It must be in hyphenated format.
+#[cfg(target_os = "macos")]
+pub fn name_to_guid(name: &str) -> Option<Uuid> {
+    if name.starts_with('{') {
+        // `Uuid::try_parse` checks for the closing brace.
+        Uuid::try_parse(name).ok()
+    } else {
+        None
+    }
 }
 
 /// Convert uid to GUID.
@@ -636,6 +648,32 @@ mod tests {
 
         let result = gid_to_name(gid)?;
         assert_eq!(result, gid.to_string());
+
+        Ok(())
+    }
+
+    /// Test `name_to_guid` converts name to a guid.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_name_to_guid() -> TestResult {
+        helper::init_logging();
+
+        let test_cases = [
+            ("{00000000-0000-0000-0000-000000000000}", Some(Uuid::nil())),
+            ("{00000000000000000000000000000000}", None), // must be hypenated
+            ("00000000000000000000000000000000", None),   // braces required
+            ("00000000-0000-0000-0000-000000000000", None), // braces required
+            ("{00000000-0000-0000-0000-000000000000", None), // braces required
+            (
+                "{abcdefab-cdef-abcd-efab-cdef00000059}",
+                Some(Uuid::parse_str("abcdefab-cdef-abcd-efab-cdef00000059")?),
+            ),
+        ];
+
+        for (name, value) in test_cases {
+            let guid = name_to_guid(name);
+            assert_eq!(guid, value, "name=`{}`", name);
+        }
 
         Ok(())
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -51,16 +51,20 @@ const MAX_BUFSIZE: usize = 1_048_576; // 1MB
 const CURLY_BRACE: char = '{';
 
 /// Convert user name to uid.
+///
+/// 1. If `name` begins with a curly brace, stop and return failure.
+/// 2. If `name` is a valid decimal number [0..2^32-1], return it as uid.
+/// 3. Look up `name` using `getpwnam` and return uid if found.
+/// 4. Otherwise, stop and return failure.
 pub fn name_to_uid(name: &str) -> io::Result<uid_t> {
     if !name.starts_with(CURLY_BRACE) {
+        // Try to parse name as a decimal user ID.
+        if let Ok(gid) = name.parse::<u32>() {
+            return Ok(gid);
+        }
         // Lookup user name using `getpwnam_r`.
         if let Some(uid) = getpwnam(name)? {
             return Ok(uid);
-        }
-
-        // Try to parse name as a decimal user ID.
-        if let Ok(num) = name.parse::<u32>() {
-            return Ok(num);
         }
     }
 
@@ -122,16 +126,20 @@ fn labtest_mock_getpwnam(name: &str) -> Option<uid_t> {
 }
 
 /// Convert group name to gid.
+///
+/// 1. If `name` begins with a curly brace, stop and return failure.
+/// 2. If `name` is a valid decimal number [0..2^32-1], return it as gid.
+/// 3. Look up `name` using `getgrnam` and return gid if found.
+/// 4. Otherwise, stop and return failure.
 pub fn name_to_gid(name: &str) -> io::Result<gid_t> {
     if !name.starts_with(CURLY_BRACE) {
+        // Try to parse name as a decimal group ID.
+        if let Ok(gid) = name.parse::<u32>() {
+            return Ok(gid);
+        }
         // Lookup group name using `getgrnam_r`.
         if let Some(gid) = getgrnam(name)? {
             return Ok(gid);
-        }
-
-        // Try to parse name as a decimal group ID.
-        if let Ok(num) = name.parse::<u32>() {
-            return Ok(num);
         }
     }
 
@@ -791,6 +799,14 @@ mod tests {
             let result = getpwuid(uid)?;
             assert_eq!(result, Some(name.into()));
         }
+
+        // Test that `name_to_uid` for "777772" returns uid=777772.
+        let result = name_to_uid("777772")?;
+        assert_eq!(result, 777_772);
+
+        // Test that `name_to_gid` for "777772" returns gid=777772.
+        let result = name_to_gid("777772")?;
+        assert_eq!(result, 777_772);
 
         // Test non-UTF-8 group name on systems where it was added.
         // Even when a group name is available, the result should be the GID

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -44,16 +44,24 @@ pub use crate::sys::{gid_t, uid_t};
 const INITIAL_BUFSIZE: usize = 4096; // 4KB
 const MAX_BUFSIZE: usize = 1_048_576; // 1MB
 
+// A name that starts with a left curly brace '{' is treated differently
+// by `name_to_uid` and `name_to_gid`. It represents an underlying GUID or
+// SID.
+
+const CURLY_BRACE: char = '{';
+
 /// Convert user name to uid.
 pub fn name_to_uid(name: &str) -> io::Result<uid_t> {
-    // Lookup user name using `getpwnam_r`.
-    if let Some(uid) = getpwnam(name)? {
-        return Ok(uid);
-    }
+    if !name.starts_with(CURLY_BRACE) {
+        // Lookup user name using `getpwnam_r`.
+        if let Some(uid) = getpwnam(name)? {
+            return Ok(uid);
+        }
 
-    // Try to parse name as a decimal user ID.
-    if let Ok(num) = name.parse::<u32>() {
-        return Ok(num);
+        // Try to parse name as a decimal user ID.
+        if let Ok(num) = name.parse::<u32>() {
+            return Ok(num);
+        }
     }
 
     fail_custom(&format!("unknown user name: {name:?}"))
@@ -115,14 +123,16 @@ fn labtest_mock_getpwnam(name: &str) -> Option<uid_t> {
 
 /// Convert group name to gid.
 pub fn name_to_gid(name: &str) -> io::Result<gid_t> {
-    // Lookup group name using `getgrnam_r`.
-    if let Some(gid) = getgrnam(name)? {
-        return Ok(gid);
-    }
+    if !name.starts_with(CURLY_BRACE) {
+        // Lookup group name using `getgrnam_r`.
+        if let Some(gid) = getgrnam(name)? {
+            return Ok(gid);
+        }
 
-    // Try to parse name as a decimal group ID.
-    if let Ok(num) = name.parse::<u32>() {
-        return Ok(num);
+        // Try to parse name as a decimal group ID.
+        if let Ok(num) = name.parse::<u32>() {
+            return Ok(num);
+        }
     }
 
     fail_custom(&format!("unknown group name: {name:?}"))
@@ -288,7 +298,7 @@ fn getgrgid(gid: gid_t) -> io::Result<Option<String>> {
 /// It must be in hyphenated format.
 #[cfg(target_os = "macos")]
 pub fn name_to_guid(name: &str) -> Option<Uuid> {
-    if name.starts_with('{') {
+    if name.starts_with(CURLY_BRACE) {
         // `Uuid::try_parse` checks for the closing brace.
         Uuid::try_parse(name).ok()
     } else {
@@ -514,6 +524,7 @@ mod tests {
             "\u{1F600}",  // grinning face emoji
             ":",
             ",",
+            "{",
         ];
 
         for name in invalid_names {
@@ -569,7 +580,7 @@ mod tests {
     fn test_numeric_name() -> TestResult {
         helper::init_logging();
 
-        let numeric_names = ["500", "0", "1", "4294967295"];
+        let numeric_names = ["500", "0", "1", "4294967295", "000004294967295"];
 
         for name in numeric_names {
             let result = name_to_uid(name)?;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -59,8 +59,8 @@ const CURLY_BRACE: char = '{';
 pub fn name_to_uid(name: &str) -> io::Result<uid_t> {
     if !name.starts_with(CURLY_BRACE) {
         // Try to parse name as a decimal user ID.
-        if let Ok(gid) = name.parse::<u32>() {
-            return Ok(gid);
+        if let Ok(uid) = name.parse::<uid_t>() {
+            return Ok(uid);
         }
         // Lookup user name using `getpwnam_r`.
         if let Some(uid) = getpwnam(name)? {
@@ -134,7 +134,7 @@ fn labtest_mock_getpwnam(name: &str) -> Option<uid_t> {
 pub fn name_to_gid(name: &str) -> io::Result<gid_t> {
     if !name.starts_with(CURLY_BRACE) {
         // Try to parse name as a decimal group ID.
-        if let Ok(gid) = name.parse::<u32>() {
+        if let Ok(gid) = name.parse::<gid_t>() {
             return Ok(gid);
         }
         // Lookup group name using `getgrnam_r`.
@@ -186,8 +186,16 @@ fn getgrnam(name: &str) -> io::Result<Option<gid_t>> {
 }
 
 /// Convert uid to user name.
+///
+/// If we look up the user name and it doesn't exist, return the original `uid`
+/// as a decimal string.
+///
+/// If we look up the user name but it's is a decimal number that could be
+/// confused for a `uid`, return the original `uid` as a decimal string.
 pub fn uid_to_name(uid: uid_t) -> io::Result<String> {
-    if let Some(name) = getpwuid(uid)? {
+    if let Some(name) = getpwuid(uid)?
+        && name.parse::<uid_t>().is_err()
+    {
         return Ok(name);
     }
 
@@ -252,8 +260,16 @@ fn labtest_mock_getpwuid(uid: uid_t) -> Option<String> {
 }
 
 /// Convert gid to group name.
+///
+/// If we look up the group name and it doesn't exist, return the original `gid`
+/// as a decimal string.
+///
+/// If we look up the group name but it's is a decimal number that could be
+/// confused for a `gid`, return the original `gid` as a decimal string.
 pub fn gid_to_name(gid: gid_t) -> io::Result<String> {
-    if let Some(name) = getgrgid(gid)? {
+    if let Some(name) = getgrgid(gid)?
+        && name.parse::<gid_t>().is_err()
+    {
         return Ok(name);
     }
 
@@ -800,19 +816,15 @@ mod tests {
             assert_eq!(result, Some(name.into()));
         }
 
-        // Test that `name_to_uid` for "777772" returns uid=777772.
-        let result = name_to_uid("777772")?;
-        assert_eq!(result, 777_772);
-
-        // Test that `name_to_gid` for "777772" returns gid=777772.
-        let result = name_to_gid("777772")?;
-        assert_eq!(result, 777_772);
+        // Test some edge cases.
+        assert_eq!(name_to_uid("777772")?, 777_772);
+        assert_eq!(uid_to_name(777_773)?, "777773");
+        assert_eq!(name_to_gid("777772")?, 777_772);
 
         // Test non-UTF-8 group name on systems where it was added.
         // Even when a group name is available, the result should be the GID
         // in decimal.
-        let result = gid_to_name(777_775)?;
-        assert_eq!(result, "777775");
+        assert_eq!(gid_to_name(777_775)?, "777775");
 
         Ok(())
     }

--- a/tests/testsuite_darwin.sh
+++ b/tests/testsuite_darwin.sh
@@ -716,7 +716,7 @@ testWriteAclToFile1_LabTestNumeric() {
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:{ffffeeee-dddd-cccc-bbbb-aaaa000bde2d},perms:[read],flags:[],allow:false}]" \
+        "[{kind:user,name:{ffffeeee-dddd-cccc-bbbb-aaaa000bde2c},perms:[read],flags:[],allow:false}]" \
         "${msg//\"/}"
 
     # Set ACL for 777773 to "deny read".

--- a/tests/testsuite_darwin.sh
+++ b/tests/testsuite_darwin.sh
@@ -62,6 +62,7 @@ oneTimeSetUp() {
     # Use temp directory managed by shunit2.
     DIR="$SHUNIT_TMPDIR"
     FILE1="$DIR/file1"
+    FILE2="$DIR/file2"
     DIR1="$DIR/dir1"
     LINK1="$DIR/link1"
     LINK2="$DIR/link2"
@@ -69,6 +70,7 @@ oneTimeSetUp() {
     # Create empty file, dir, and links.
     umask 077
     touch "$FILE1"
+    touch "$FILE2"
     mkdir "$DIR1"
     ln -s link1_to_nowhere "$LINK1"
     ln -s file1 "$LINK2"
@@ -668,11 +670,11 @@ testWriteAclToFile1_LabTest() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Read ACL (note assymetry).
+    # Read ACL.
     msg=$($EXACL $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:777772,perms:[read],flags:[],allow:false}]" \
+        "[{kind:user,name:777773,perms:[read],flags:[],allow:false}]" \
         "${msg//\"/}"
 
     # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "deny read".
@@ -744,6 +746,48 @@ testWriteAclToFile1_LabTestNumeric() {
     assertEquals \
         "[{kind:user,name:{ffffeeee-dddd-cccc-bbbb-aaaa000bde2e},perms:[read],flags:[],allow:false}]" \
         "${msg//\"/}"
+}
+
+# This test verifies that an ACL copied from 1 file to another executes properly even
+# on the weird _LABTEST system.
+testCopyAcl_LabTest() {
+    input="[
+        {kind:user,name:\"🧪\",perms:[read],flags:[],allow:false},
+        {kind:user,name:777772,perms:[read],flags:[],allow:false},
+        {kind:user,name:777773,perms:[read],flags:[],allow:false},
+        {kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:false},
+        {kind:group,name:777775,perms:[read],flags:[],allow:false}
+    ]"
+    input=$(quotifyJson "$input")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+
+    # Copy ACL from FILE1 to FILE2.
+    msg=$($EXACL -n $FILE1 | $EXACL --set $FILE2 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Numeric ACL's are equal.
+    acl1=$($EXACL -n $FILE1)
+    acl2=$($EXACL -n $FILE2)
+    assertEquals "$acl1" "$acl2"
+
+    # Human-readable ACL's are equal.
+    acl1=$($EXACL -f std $FILE1)
+    acl2=$($EXACL -f std $FILE2)
+    assertEquals "$acl1" "$acl2"
+
+    expected="\
+deny::user:🧪:read
+deny::user:777772:read
+deny::user:777773:read
+deny::user:fbbc14b7-95f9-47a7-8ee8-1cccb9220943:read
+deny::group:777775:read"
+    assertEquals "$acl1" "$expected"
 }
 
 # shellcheck disable=SC1091

--- a/tests/testsuite_darwin.sh
+++ b/tests/testsuite_darwin.sh
@@ -503,8 +503,9 @@ testWriteAclNumericGID() {
 
 testWriteAclGUID_group() {
     # Set ACL for _spotlight group to "deny read" using GUID.
-    spotlight_group="ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000059"
-    input=$(quotifyJson "[{kind:group,name:$spotlight_group,perms:[read],flags:[],allow:false}]")
+    spotlight_group="{ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000059}"
+    input=$(quotifyJson "[{kind:group,name:SPOTLIGHT_GROUP,perms:[read],flags:[],allow:false}]")
+    input=${input/SPOTLIGHT_GROUP/$spotlight_group}
     msg=$(echo "$input" | $EXACL --set $FILE1 2>&1)
     assertEquals 0 $?
     assertEquals "" "$msg"
@@ -524,8 +525,9 @@ testWriteAclGUID_group() {
 
 testWriteAclGUID_nil_user() {
     # Set ACL for NIL-GUID *user* to "deny read" using GUID.
-    nil_uuid="00000000-0000-0000-0000-000000000000"
-    input=$(quotifyJson "[{kind:user,name:$nil_uuid,perms:[read],flags:[],allow:false}]")
+    nil_uuid="{00000000-0000-0000-0000-000000000000}"
+    input=$(quotifyJson "[{kind:user,name:NIL_UUID,perms:[read],flags:[],allow:false}]")
+    input=${input/NIL_UUID/$nil_uuid}
     msg=$(echo "$input" | $EXACL --set $FILE1 2>&1)
     assertEquals 0 $?
     assertEquals "" "$msg"
@@ -545,8 +547,9 @@ testWriteAclGUID_nil_user() {
 
 testWriteAclGUID_nil_group() {
     # Set ACL for NIL-GUID *group* to "deny read" using GUID.
-    nil_uuid="00000000-0000-0000-0000-000000000000"
-    input=$(quotifyJson "[{kind:group,name:$nil_uuid,perms:[read],flags:[],allow:false}]")
+    nil_uuid="{00000000-0000-0000-0000-000000000000}"
+    input=$(quotifyJson "[{kind:group,name:NIL_UUID,perms:[read],flags:[],allow:false}]")
+    input=${input/NIL_UUID/$nil_uuid}
     msg=$(echo "$input" | $EXACL --set $FILE1 2>&1)
     assertEquals 0 $?
     assertEquals "" "$msg"
@@ -566,8 +569,9 @@ testWriteAclGUID_nil_group() {
 
 testWriteAclGUID_random_guid() {
     # Set ACL for RANDOM-GUID *user* to "deny write" using GUID.
-    random_guid="e08f1961-f45c-47c5-9cfd-d367de5874f8"
-    input=$(quotifyJson "[{kind:user,name:$random_guid,perms:[write],flags:[],allow:false}]")
+    random_guid="{e08f1961-f45c-47c5-9cfd-d367de5874f8}"
+    input=$(quotifyJson "[{kind:user,name:RANDOM_GUID,perms:[write],flags:[],allow:false}]")
+    input=${input/RANDOM_GUID/$random_guid}
     msg=$(echo "$input" | $EXACL --set $FILE1 2>&1)
     assertEquals 0 $?
     assertEquals "" "$msg"

--- a/tests/testsuite_darwin.sh
+++ b/tests/testsuite_darwin.sh
@@ -17,10 +17,10 @@ fi
 
 ME=$(id -un)
 ME_NUM=$(id -u)
-# ME_GUID=$(dscl . -read /Users/$ME GeneratedUID | awk '{print tolower($2)}')
+ME_GUID=$(dscl . -read /Users/$ME GeneratedUID | awk '{print tolower($2)}')
 MY_GROUP=$(id -gn)
 MY_GROUP_NUM=$(id -g)
-# MY_GROUP_GUID=$(dscl . -read /Groups/$MY_GROUP GeneratedUID | awk '{print tolower($2)}')
+MY_GROUP_GUID=$(dscl . -read /Groups/$MY_GROUP GeneratedUID | awk '{print tolower($2)}')
 
 # Return true if file is readable.
 isReadable() {
@@ -139,7 +139,7 @@ testReadAclForFile1_Numeric() {
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:$ME_NUM,perms:[read],flags:[],allow:false}]" \
+        "[{kind:user,name:{$ME_GUID},perms:[read],flags:[],allow:false}]" \
         "${msg//\"/}"
 
     ! isReadable "$FILE1" && isWritable "$FILE1"
@@ -156,7 +156,7 @@ testReadAclForFile1_Numeric() {
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:$ME_NUM,perms:[read],flags:[],allow:false},{kind:group,name:$MY_GROUP_NUM,perms:[write],flags:[],allow:true}]" \
+        "[{kind:user,name:{$ME_GUID},perms:[read],flags:[],allow:false},{kind:user,name:{$MY_GROUP_GUID},perms:[write],flags:[],allow:true}]" \
         "${msg//\"/}"
 
     ! isReadable "$FILE1" && isWritable "$FILE1"
@@ -703,7 +703,7 @@ testWriteAclToFile1_LabTestNumeric() {
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:777771,perms:[read],flags:[],allow:false}]" \
+        "[{kind:user,name:{ffffeeee-dddd-cccc-bbbb-aaaa000bde2b},perms:[read],flags:[],allow:false}]" \
         "${msg//\"/}"
 
     # Set ACL for 777772 to "deny read".
@@ -716,7 +716,7 @@ testWriteAclToFile1_LabTestNumeric() {
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:777773,perms:[read],flags:[],allow:false}]" \
+        "[{kind:user,name:{ffffeeee-dddd-cccc-bbbb-aaaa000bde2d},perms:[read],flags:[],allow:false}]" \
         "${msg//\"/}"
 
     # Set ACL for 777773 to "deny read".
@@ -729,7 +729,7 @@ testWriteAclToFile1_LabTestNumeric() {
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:777773,perms:[read],flags:[],allow:false}]" \
+        "[{kind:user,name:{ffffeeee-dddd-cccc-bbbb-aaaa000bde2d},perms:[read],flags:[],allow:false}]" \
         "${msg//\"/}"
 
     # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "deny read".
@@ -742,7 +742,7 @@ testWriteAclToFile1_LabTestNumeric() {
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:777774,perms:[read],flags:[],allow:false}]" \
+        "[{kind:user,name:{ffffeeee-dddd-cccc-bbbb-aaaa000bde2e},perms:[read],flags:[],allow:false}]" \
         "${msg//\"/}"
 }
 

--- a/tests/testsuite_freebsd_acls.sh
+++ b/tests/testsuite_freebsd_acls.sh
@@ -682,11 +682,11 @@ testWriteAclToFile1_LabTestNumeric() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Read ACL (note asymmetry).
+    # Read ACL.
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777773,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777772,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
         "${msg//\"/}"
 
     # Set ACL for 777773 to "allow read".

--- a/tests/testsuite_freebsd_acls.sh
+++ b/tests/testsuite_freebsd_acls.sh
@@ -635,11 +635,11 @@ testWriteAclToFile1_LabTest() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Read ACL (note asymmetry).
+    # Read ACL.
     msg=$($EXACL $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777772,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777773,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
         "${msg//\"/}"
 
     # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "allow read".

--- a/tests/testsuite_freebsd_acls.sh
+++ b/tests/testsuite_freebsd_acls.sh
@@ -59,12 +59,14 @@ oneTimeSetUp() {
     # Use temp directory managed by shunit2.
     DIR="$SHUNIT_TMPDIR"
     FILE1="$DIR/file1"
+    FILE2="$DIR/file2"
     DIR1="$DIR/dir1"
     LINK1="$DIR/link1"
 
     # Create empty file, dir, and link.
     umask 077
     touch "$FILE1"
+    touch "$FILE2"
     mkdir "$DIR1"
     ln -s link1_to_nowhere "$LINK1"
 }

--- a/tests/testsuite_freebsd_acls.sh
+++ b/tests/testsuite_freebsd_acls.sh
@@ -716,5 +716,50 @@ testWriteAclToFile1_LabTestNumeric() {
         "${msg//\"/}"
 }
 
+# This test verifies that an ACL copied from 1 file to another executes properly even
+# on the weird _LABTEST system.
+testCopyAcl_LabTest() {
+    # The 3 required entries for Linux.
+    required=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
+
+    input="[
+        {kind:user,name:\"🧪\",perms:[read],flags:[],allow:true},
+        {kind:user,name:777772,perms:[read],flags:[],allow:true},
+        {kind:user,name:777773,perms:[read],flags:[],allow:true},
+        {kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true},
+        {kind:group,name:777775,perms:[read],flags:[],allow:true}
+    ]"
+    input=$(quotifyJson "$input")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+
+    # Copy ACL from FILE1 to FILE2.
+    msg=$($EXACL -n $FILE1 | $EXACL --set $FILE2 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Numeric ACL's are equal.
+    acl1=$($EXACL -n $FILE1)
+    acl2=$($EXACL -n $FILE2)
+    assertEquals "$acl1" "$acl2"
+
+    # Human-readable ACL's are equal.
+    acl1=$($EXACL -f std $FILE1)
+    acl2=$($EXACL -f std $FILE2)
+    assertEquals "$acl1" "$acl2"
+
+    expected="\
+allow::user:🧪:read
+allow::user:777772:read
+allow::user:777773:read
+allow::user:fbbc14b7-95f9-47a7-8ee8-1cccb9220943:read
+allow::group:777775:read"
+    assertEquals "$acl1" "$expected"
+}
+
 # shellcheck disable=SC1091
 . shunit2

--- a/tests/testsuite_freebsd_acls.sh
+++ b/tests/testsuite_freebsd_acls.sh
@@ -755,11 +755,15 @@ testCopyAcl_LabTest() {
     assertEquals "$acl1" "$acl2"
 
     expected="\
+allow::user::read,write
 allow::user:🧪:read
 allow::user:777772:read
 allow::user:777773:read
 allow::user:fbbc14b7-95f9-47a7-8ee8-1cccb9220943:read
-allow::group:777775:read"
+allow::group::
+allow::group:777775:read
+allow::mask::read
+allow::other::"
     assertEquals "$acl1" "$expected"
 }
 

--- a/tests/testsuite_freebsd_nfsv4acls.sh
+++ b/tests/testsuite_freebsd_nfsv4acls.sh
@@ -28,12 +28,14 @@ oneTimeSetUp() {
     # Use temp directory managed by shunit2.
     DIR="$SHUNIT_TMPDIR"
     FILE1="$DIR/file1"
+    FILE2="$DIR/file2"
     DIR1="$DIR/dir1"
     LINK1="$DIR/link1"
 
     # Create empty file, dir, and link.
     umask 077
     touch "$FILE1"
+    touch "$FILE2"
     mkdir "$DIR1"
     ln -s link1_to_nowhere "$LINK1"
 }

--- a/tests/testsuite_freebsd_nfsv4acls.sh
+++ b/tests/testsuite_freebsd_nfsv4acls.sh
@@ -780,14 +780,14 @@ testWriteAclToFile1_LabTestNumeric() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Read ACL. (note asymmetry)
+    # Read ACL.
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:777773,perms:[read_data],flags:[],allow:false}]" \
+        "[{kind:user,name:777772,perms:[read_data],flags:[],allow:false}]" \
         "${msg//\"/}"
 
-    # Set ACL for 777773 to "allow read".
+    # Set ACL for 777773 to "deny read".
     input=$(quotifyJson "[{kind:user,name:777773,perms:[read_data],flags:[],allow:false}]")
     msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
     assertEquals 0 $?

--- a/tests/testsuite_freebsd_nfsv4acls.sh
+++ b/tests/testsuite_freebsd_nfsv4acls.sh
@@ -736,11 +736,11 @@ testWriteAclToFile1_LabTest() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Read ACL (note asymmetry).
+    # Read ACL.
     msg=$($EXACL $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:777772,perms:[read_data],flags:[],allow:false}]" \
+        "[{kind:user,name:777773,perms:[read_data],flags:[],allow:false}]" \
         "${msg//\"/}"
 
     # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "deny read".

--- a/tests/testsuite_freebsd_nfsv4acls.sh
+++ b/tests/testsuite_freebsd_nfsv4acls.sh
@@ -814,5 +814,47 @@ testWriteAclToFile1_LabTestNumeric() {
         "${msg//\"/}"
 }
 
+# This test verifies that an ACL copied from 1 file to another executes properly even
+# on the weird _LABTEST system.
+testCopyAcl_LabTest() {
+    input="[
+        {kind:user,name:\"🧪\",perms:[read_data],flags:[],allow:false},
+        {kind:user,name:777772,perms:[read_data],flags:[],allow:false},
+        {kind:user,name:777773,perms:[read_data],flags:[],allow:false},
+        {kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read_data],flags:[],allow:false},
+        {kind:group,name:777775,perms:[read_data],flags:[],allow:false}
+    ]"
+    input=$(quotifyJson "$input")
+    msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+
+    # Copy ACL from FILE1 to FILE2.
+    msg=$($EXACL -n $FILE1 | $EXACL --set $FILE2 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Numeric ACL's are equal.
+    acl1=$($EXACL -n $FILE1)
+    acl2=$($EXACL -n $FILE2)
+    assertEquals "$acl1" "$acl2"
+
+    # Human-readable ACL's are equal.
+    acl1=$($EXACL -f std $FILE1)
+    acl2=$($EXACL -f std $FILE2)
+    assertEquals "$acl1" "$acl2"
+
+    expected="\
+deny::user:🧪:read_data
+deny::user:777772:read_data
+deny::user:777773:read_data
+deny::user:fbbc14b7-95f9-47a7-8ee8-1cccb9220943:read_data
+deny::group:777775:read_data"
+    assertEquals "$acl1" "$expected"
+}
+
 # shellcheck disable=SC1091
 . shunit2

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -782,11 +782,11 @@ testWriteAclToFile1_LabTestNumeric() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Read ACL (note asymmetry).
+    # Read ACL.
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777773,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777772,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
         "${msg//\"/}"
 
     # Set ACL for 777773 to "allow read".

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -855,11 +855,15 @@ testCopyAcl_LabTest() {
     assertEquals "$acl1" "$acl2"
 
     expected="\
+allow::user::read,write
 allow::user:🧪:read
 allow::user:777772:read
 allow::user:777773:read
 allow::user:fbbc14b7-95f9-47a7-8ee8-1cccb9220943:read
-allow::group:777775:read"
+allow::group::
+allow::group:777775:read
+allow::mask::read
+allow::other::"
     assertEquals "$acl1" "$expected"
 }
 

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -77,12 +77,14 @@ oneTimeSetUp() {
     # Use temp directory managed by shunit2.
     DIR="$SHUNIT_TMPDIR"
     FILE1="$DIR/file1"
+    FILE2="$DIR/file2"
     DIR1="$DIR/dir1"
     LINK1="$DIR/link1"
 
     # Create empty file, dir, and link.
     umask 077
     touch "$FILE1"
+    touch "$FILE2"
     mkdir "$DIR1"
     ln -s link1_to_nowhere "$LINK1"
 }

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -735,11 +735,11 @@ testWriteAclToFile1_LabTest() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Read ACL (note asymmetry).
+    # Read ACL.
     msg=$($EXACL $FILE1)
     assertEquals 0 $?
     assertEquals \
-        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777772,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
+        "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:user,name:777773,perms:[read],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:mask,name:,perms:[read],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]" \
         "${msg//\"/}"
 
     # Set ACL for fbbc14b7-95f9-47a7-8ee8-1cccb9220943 to "allow read".

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -816,5 +816,50 @@ testWriteAclToFile1_LabTestNumeric() {
         "${msg//\"/}"
 }
 
+# This test verifies that an ACL copied from 1 file to another executes properly even
+# on the weird _LABTEST system.
+testCopyAcl_LabTest() {
+    # The 3 required entries for Linux.
+    required=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
+
+    input="[
+        {kind:user,name:\"🧪\",perms:[read],flags:[],allow:true},
+        {kind:user,name:777772,perms:[read],flags:[],allow:true},
+        {kind:user,name:777773,perms:[read],flags:[],allow:true},
+        {kind:user,name:fbbc14b7-95f9-47a7-8ee8-1cccb9220943,perms:[read],flags:[],allow:true},
+        {kind:group,name:777775,perms:[read],flags:[],allow:true}
+    ]"
+    input=$(quotifyJson "$input")
+    msg=$($EXACL --set --acl "$input" --acl "$required" $FILE1 2>&1)
+    if [ "$msg" = 'Invalid ACL: entry 0: unknown user name: "🧪"' ]; then
+        echo " _LABTEST not enabled."
+        return 0
+    fi
+    assertEquals "" "$msg"
+
+    # Copy ACL from FILE1 to FILE2.
+    msg=$($EXACL -n $FILE1 | $EXACL --set $FILE2 2>&1)
+    assertEquals 0 $?
+    assertEquals "" "$msg"
+
+    # Numeric ACL's are equal.
+    acl1=$($EXACL -n $FILE1)
+    acl2=$($EXACL -n $FILE2)
+    assertEquals "$acl1" "$acl2"
+
+    # Human-readable ACL's are equal.
+    acl1=$($EXACL -f std $FILE1)
+    acl2=$($EXACL -f std $FILE2)
+    assertEquals "$acl1" "$acl2"
+
+    expected="\
+allow::user:🧪:read
+allow::user:777772:read
+allow::user:777773:read
+allow::user:fbbc14b7-95f9-47a7-8ee8-1cccb9220943:read
+allow::group:777775:read"
+    assertEquals "$acl1" "$expected"
+}
+
 # shellcheck disable=SC1091
 . shunit2


### PR DESCRIPTION
- GUID's on macOS are now formatted in curly braces and must be hyphenated as UUID's.
- Names that begin with curly brace '{' are never looked up in directory services; they fall back to local/native support if available (currently macOS only).
- On macOS, the NUMERIC_ACL option now returns the GUID, not the uid/gid.
- Numeric decimal names are now always treated as uid/gid, even on weird systems with ambiguous numeric user/group names. This goes for name_to_uid and uid_to_name lookups. (Change in order of name input parsing.)
- Add test for copying an ACL from one file to another on _LABTEST systems.
