### PR TITLE
Prevent return of names that begin with '{'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ setfacl(&["./tmp/foo"], &acl, None)?;
 - Supports reading/writing of ACL's as delimited text.
 - Supports serde (optional) for easy reading/writing of ACL's to JSON, YAML and other common formats.
 
+There are two main flavors of ACL's: Posix and Extended.
+
+| Operating System | Posix |  Extended |
+| -----------------| -------- | -------- |
+| Linux | ✅ | ❌ |
+| macOS | ❌ | ✅ |
+| FreeBSD | ✅ | ✅ |
+
 ## API
 
 This module provides two high level functions, `getfacl` and `setfacl`.

--- a/src/aclentry.rs
+++ b/src/aclentry.rs
@@ -47,9 +47,39 @@ pub enum AclEntryKind {
 
 /// ACL entry with allow/deny semantics.
 ///
+/// Each ACL entry is identified by a `kind` and a `name`. Together, these
+/// specify the user or group that is being given (or denied) access.
+///
+/// # Naming
+///
+/// The `name` field can specify a human-readable name, a numeric ID, or a
+/// platform-specific ID.
+///
+/// 1. If the name begins with a curly brace '{', it is treated as a
+///    platform-specific ID. On macOS, this is a GUID which must be enclosed
+///    in curly braces and formatted as a UUID in 8-4-4-4-12 format.
+///    Example: `{fbbc14b7-95f9-47a7-8ee8-1cccb9220943}`
+/// 2. If the name is a decimal integer in the range [0..2^32-1], it is treated
+///    as a UID or GID. Example: `501`
+/// 3. Otherwise, the name is converted to the underlying UID/GID using local
+///    API calls (e.g. getpwnam, getgrnam depending on `kind`).
+///    Example: `bin`
+///
+/// It is not possible to represent certain user or group names that may be
+/// present on unusual systems:
+///
+/// - Names that contain non-UTF-8 bytes.
+/// - Names that consist entirely of decimal digits in the range [0..2^32-1].
+/// - Names that begin with '{'.
+///
+/// With `setfacl`, you must use the numeric UID/GID instead of the
+/// invalid name.
+///
+/// If present, `getfacl` will return ACL entries with the `name` set to the
+/// decimal UID or GID instead of the invalid or ambiguous name.
+///
 /// ACL entries are ordered so sorting will automatically put the ACL in
 /// canonical order.
-///
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
@@ -58,7 +88,7 @@ pub struct AclEntry {
     pub kind: AclEntryKind,
 
     /// Name of the principal being given access. You can use a user/group name
-    /// or decimal uid/gid. On macOS you can use a UUID.
+    /// or decimal uid/gid. On macOS you can use a UUID in curly braces.
     pub name: String,
 
     /// Permission bits for the entry.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -2,7 +2,7 @@
 //
 // This module supports a `_LABTEST` cfg flag that adds some synthetic
 // name/uid mappings. These are designed to catch some edge cases in testing.
-// To use the _LABTEST cfg flag, code has to be explicitly compiled by cargo in
+// To use the _LABTEST cfg flag, the code has to be explicitly compiled in
 // debug mode with `RUSTFLAGS="--cfg _LABTEST"`. You can detect code is
 // compiled with _LABTEST by using the 🧪 emoji as a user name. The group name
 // mapping is tested on FreeBSD by adding the group name manually to /etc/group.
@@ -191,10 +191,12 @@ fn getgrnam(name: &str) -> io::Result<Option<gid_t>> {
 /// as a decimal string.
 ///
 /// If we look up the user name but it's is a decimal number that could be
-/// confused for a `uid`, return the original `uid` as a decimal string.
+/// confused for a `uid` or it starts with '{', return the original `uid` as a
+/// decimal string.
 pub fn uid_to_name(uid: uid_t) -> io::Result<String> {
     if let Some(name) = getpwuid(uid)?
         && name.parse::<uid_t>().is_err()
+        && !name.starts_with(CURLY_BRACE)
     {
         return Ok(name);
     }
@@ -265,10 +267,12 @@ fn labtest_mock_getpwuid(uid: uid_t) -> Option<String> {
 /// as a decimal string.
 ///
 /// If we look up the group name but it's is a decimal number that could be
-/// confused for a `gid`, return the original `gid` as a decimal string.
+/// confused for a `gid` or it starts with '{', return the original `gid` as a
+/// decimal string.
 pub fn gid_to_name(gid: gid_t) -> io::Result<String> {
     if let Some(name) = getgrgid(gid)?
         && name.parse::<gid_t>().is_err()
+        && !name.starts_with(CURLY_BRACE)
     {
         return Ok(name);
     }


### PR DESCRIPTION
- Minor documentation edits.