### PR TITLE
Rename NUMERIC_ACL AclOption to NATIVE_ID. 

### DIFF
--- a/examples/exacl.rs
+++ b/examples/exacl.rs
@@ -45,9 +45,9 @@ struct Opt {
     #[arg(short = 's', long)]
     symlink: bool,
 
-    /// Get ACL as numeric only.
+    /// Get ACL as native ID only.
     #[arg(short = 'n', long)]
-    numeric: bool,
+    native: bool,
 
     /// Set ACL to specified value (may combine multiple ACL's).
     #[arg(long)]
@@ -87,8 +87,8 @@ fn main() {
     if opt.symlink {
         options |= AclOption::SYMLINK_ACL;
     }
-    if opt.numeric {
-        options |= AclOption::NUMERIC_ACL;
+    if opt.native {
+        options |= AclOption::NATIVE_ID;
     }
 
     let exit_code = if opt.set {

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -28,8 +28,10 @@ bitflags! {
         /// Get/set the ACL of the symlink itself (macOS only).
         const SYMLINK_ACL = 0b0100;
 
-        /// Retrieve numeric user and group ID's (decimal numbers).
-        const NUMERIC_ACL = 0b1000;
+        /// Retrieve name representation that uses the lowest, native system
+        /// representation of each user or group. This is a numeric decimal
+        /// UID/GID on Linux/FreeBSD and a GUID on macOS.
+        const NATIVE_ID = 0b1000;
 
         /// Ignore expected error when using DEFAULT_ACL on a file.
         #[doc(hidden)]
@@ -311,17 +313,17 @@ impl Acl {
 
     /// Return ACL as a vector of [`AclEntry`].
     ///
-    /// If `numeric` is true, retrieve the numeric uid/gid values instead of
+    /// If `native` is true, retrieve the numeric uid/gid values instead of
     /// translating them to names.
     ///
     /// # Errors
     ///
     /// Returns an [`io::Error`] on failure.
-    pub fn entries(&self, numeric: bool) -> io::Result<Vec<AclEntry>> {
+    pub fn entries(&self, native: bool) -> io::Result<Vec<AclEntry>> {
         let mut entries = Vec::<AclEntry>::with_capacity(8);
 
         xacl_foreach(self.acl, |entry_p| {
-            let entry = AclEntry::from_raw(entry_p, self.acl, numeric)?;
+            let entry = AclEntry::from_raw(entry_p, self.acl, native)?;
             entries.push(entry);
             Ok(())
         })?;
@@ -465,7 +467,7 @@ deny:file_inherit,directory_inherit:group:11504:read,write,execute
         assert_eq!(entries2, entries);
         assert_eq!(entries2[0].name, "_spotlight");
 
-        // Test numeric option.
+        // Test native option.
         let entries3 = acl2.entries(true)?;
         assert_eq!(entries3[0].name, "{abcdefab-cdef-abcd-efab-cdef00000059}");
 
@@ -522,7 +524,7 @@ allow::other::read,write,execute
         assert_eq!(entries2, entries);
         assert_eq!(entries2[5].name, "bin");
 
-        // Test numeric option with "bin" group.
+        // Test native option with "bin" group.
         entries2 = acl2.entries(true)?;
         entries2.sort();
         #[cfg(target_os = "linux")] // FIXME: test code should look these up.

--- a/src/aclentry.rs
+++ b/src/aclentry.rs
@@ -225,53 +225,53 @@ impl AclEntry {
 
     /// Return an `AclEntry` constructed from a native `acl_entry_t`.
     ///
-    /// If `numeric` is true, retrieve numeric uid/gid instead of translating
-    /// names. On macOS, `numeric` returns the GUID.
-    pub(crate) fn from_raw(entry: acl_entry_t, acl: acl_t, numeric: bool) -> io::Result<AclEntry> {
+    /// If `native` is true, retrieve numeric uid/gid instead of translating
+    /// names. On macOS, `native` returns the GUID.
+    pub(crate) fn from_raw(entry: acl_entry_t, acl: acl_t, native: bool) -> io::Result<AclEntry> {
         let (allow, qualifier, perms, flags) = xacl_get_entry(acl, entry)?;
 
         let (kind, name) = match qualifier {
             Qualifier::Unknown(s) => (AclEntryKind::Unknown, s),
 
             #[cfg(target_os = "macos")]
-            Qualifier::User(_) => (AclEntryKind::User, qualifier.name(numeric)?),
+            Qualifier::User(_) => (AclEntryKind::User, qualifier.name(native)?),
 
             #[cfg(target_os = "macos")]
-            Qualifier::Group(_) => (AclEntryKind::Group, qualifier.name(numeric)?),
+            Qualifier::Group(_) => (AclEntryKind::Group, qualifier.name(native)?),
 
             #[cfg(target_os = "macos")]
-            Qualifier::Guid(_) if numeric => (AclEntryKind::User, qualifier.name(true)?),
+            Qualifier::Guid(_) if native => (AclEntryKind::User, qualifier.name(true)?),
 
             #[cfg(target_os = "macos")]
             Qualifier::Guid(_) => {
                 let translated = qualifier.translate_guid()?;
                 match translated {
                     Qualifier::User(_) | Qualifier::Guid(_) => {
-                        (AclEntryKind::User, translated.name(numeric)?)
+                        (AclEntryKind::User, translated.name(native)?)
                     }
-                    Qualifier::Group(_) => (AclEntryKind::Group, translated.name(numeric)?),
+                    Qualifier::Group(_) => (AclEntryKind::Group, translated.name(native)?),
                     Qualifier::Unknown(s) => (AclEntryKind::Unknown, s),
                 }
             }
 
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
             Qualifier::User(_) | Qualifier::UserObj => {
-                (AclEntryKind::User, qualifier.name(numeric)?)
+                (AclEntryKind::User, qualifier.name(native)?)
             }
 
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
             Qualifier::Group(_) | Qualifier::GroupObj => {
-                (AclEntryKind::Group, qualifier.name(numeric)?)
+                (AclEntryKind::Group, qualifier.name(native)?)
             }
 
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-            Qualifier::Mask => (AclEntryKind::Mask, qualifier.name(numeric)?),
+            Qualifier::Mask => (AclEntryKind::Mask, qualifier.name(native)?),
 
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-            Qualifier::Other => (AclEntryKind::Other, qualifier.name(numeric)?),
+            Qualifier::Other => (AclEntryKind::Other, qualifier.name(native)?),
 
             #[cfg(target_os = "freebsd")]
-            Qualifier::Everyone => (AclEntryKind::Everyone, qualifier.name(numeric)?),
+            Qualifier::Everyone => (AclEntryKind::Everyone, qualifier.name(native)?),
         };
 
         Ok(AclEntry {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ use failx::fail_custom;
 ///
 /// [`AclOption::DEFAULT_ACL`] option is not supported on macOS.
 ///
-/// [`AclOption::NUMERIC_ACL`] option returns the `GeneratedUID` (GUID) on macOS
+/// [`AclOption::NATIVE_ID`] option returns the `GeneratedUID` (GUID) on macOS
 /// instead of translating to human-readable user/group names.
 ///
 /// # Linux
@@ -115,7 +115,7 @@ use failx::fail_custom;
 /// default ACL, if present for a directory path. When called with
 /// [`AclOption::DEFAULT_ACL`], `getfacl` may return zero entries.
 ///
-/// [`AclOption::NUMERIC_ACL`] option returns the numeric UID/GID instead of
+/// [`AclOption::NATIVE_ID`] option returns the numeric UID/GID instead of
 /// translating to human-readable user/group names.
 ///
 /// # Example
@@ -142,29 +142,29 @@ where
 
 #[cfg(target_os = "macos")]
 fn my_getfacl(path: &Path, options: AclOption) -> io::Result<Vec<AclEntry>> {
-    let numeric = options.contains(AclOption::NUMERIC_ACL);
+    let native = options.contains(AclOption::NATIVE_ID);
 
-    Acl::read(path, options)?.entries(numeric)
+    Acl::read(path, options)?.entries(native)
 }
 
 #[cfg(not(target_os = "macos"))]
 fn my_getfacl(path: &Path, options: AclOption) -> io::Result<Vec<AclEntry>> {
-    let numeric = options.contains(AclOption::NUMERIC_ACL);
+    let native = options.contains(AclOption::NATIVE_ID);
 
     if options.contains(AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL) {
         fail_custom("ACCESS_ACL and DEFAULT_ACL are mutually exclusive options")
     } else if options.intersects(AclOption::ACCESS_ACL | AclOption::DEFAULT_ACL) {
-        Acl::read(path, options)?.entries(numeric)
+        Acl::read(path, options)?.entries(native)
     } else {
         let acl = Acl::read(path, options)?;
-        let mut entries = acl.entries(numeric)?;
+        let mut entries = acl.entries(native)?;
 
         if acl.is_posix() {
             let mut default = Acl::read(
                 path,
                 options | AclOption::DEFAULT_ACL | AclOption::IGNORE_EXPECTED_FILE_ERR,
             )?
-            .entries(numeric)?;
+            .entries(native)?;
 
             entries.append(&mut default);
         }

--- a/src/qualifier.rs
+++ b/src/qualifier.rs
@@ -123,12 +123,13 @@ impl Qualifier {
 
     /// Return the name of the user/group.
     ///
-    /// If `numeric` is true, return numeric uid/gid.
-    pub fn name(&self, numeric: bool) -> io::Result<String> {
+    /// If `native` is true, return the numeric uid/gid or the underlying GUID
+    /// on macOS.
+    pub fn name(&self, native: bool) -> io::Result<String> {
         let result = match self {
-            Qualifier::User(uid) if numeric => uid.to_string(),
+            Qualifier::User(uid) if native => uid.to_string(),
             Qualifier::User(uid) => unix::uid_to_name(*uid)?,
-            Qualifier::Group(gid) if numeric => gid.to_string(),
+            Qualifier::Group(gid) if native => gid.to_string(),
             Qualifier::Group(gid) => unix::gid_to_name(*gid)?,
             #[cfg(target_os = "macos")]
             Qualifier::Guid(guid) => guid.as_braced().to_string(),
@@ -277,7 +278,7 @@ mod tests {
 
         #[cfg(target_os = "macos")]
         {
-            // Test `name` method on a Guid on macOS (numeric has no effect).
+            // Test `name` method on a Guid on macOS (native has no effect).
             let uuid = Uuid::parse_str("abcdefab-cdef-abcd-efab-cdef00000059")?;
             let guid = Qualifier::Guid(uuid);
             assert_eq!(guid.name(false)?, "{abcdefab-cdef-abcd-efab-cdef00000059}");

--- a/tests/testsuite_darwin.sh
+++ b/tests/testsuite_darwin.sh
@@ -126,8 +126,8 @@ testReadAclForFile1() {
     chmod -N "$FILE1"
 }
 
-testReadAclForFile1_Numeric() {
-    # Same test as above, but using `--numeric` option.
+testReadAclForFile1_Native() {
+    # Same test as above, but using `--native` option.
     msg=$($EXACL -n $FILE1)
     assertEquals 0 $?
     assertEquals "[]" "$msg"
@@ -691,7 +691,7 @@ testWriteAclToFile1_LabTest() {
         "${msg//\"/}"
 }
 
-testWriteAclToFile1_LabTestNumeric() {
+testWriteAclToFile1_LabTestNative() {
     # Set ACL for 🧪 to "deny read".
     input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read],flags:[],allow:false}]")
     msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
@@ -771,7 +771,7 @@ testCopyAcl_LabTest() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Numeric ACL's are equal.
+    # Native ACL's are equal.
     acl1=$($EXACL -n $FILE1)
     acl2=$($EXACL -n $FILE2)
     assertEquals "$acl1" "$acl2"

--- a/tests/testsuite_freebsd_acls.sh
+++ b/tests/testsuite_freebsd_acls.sh
@@ -658,7 +658,7 @@ testWriteAclToFile1_LabTest() {
         "${msg//\"/}"
 }
 
-testWriteAclToFile1_LabTestNumeric() {
+testWriteAclToFile1_LabTestNative() {
     # The 3 required entries for Linux.
     required=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
 
@@ -744,7 +744,7 @@ testCopyAcl_LabTest() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Numeric ACL's are equal.
+    # Native ACL's are equal.
     acl1=$($EXACL -n $FILE1)
     acl2=$($EXACL -n $FILE2)
     assertEquals "$acl1" "$acl2"

--- a/tests/testsuite_freebsd_nfsv4acls.sh
+++ b/tests/testsuite_freebsd_nfsv4acls.sh
@@ -127,8 +127,8 @@ allow::everyone::readextattr,readattr,readsecurity,sync" \
         "${msg//\"/}"
 }
 
-testReadAclForFile1_Numeric() {
-    # Same as above, but uses --numeric option.
+testReadAclForFile1_Native() {
+    # Same as above, but uses --native option.
     msg=$($EXACL -n -f std $FILE1)
     assertEquals 0 $?
     assertEquals \
@@ -759,7 +759,7 @@ testWriteAclToFile1_LabTest() {
         "${msg//\"/}"
 }
 
-testWriteAclToFile1_LabTestNumeric() {
+testWriteAclToFile1_LabTestNative() {
     # Set ACL for 🧪 to "deny read".
     input=$(quotifyJson "[{kind:user,name:\"🧪\",perms:[read_data],flags:[],allow:false}]")
     msg=$($EXACL --set --acl "$input" $FILE1 2>&1)
@@ -839,7 +839,7 @@ testCopyAcl_LabTest() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Numeric ACL's are equal.
+    # Native ACL's are equal.
     acl1=$($EXACL -n $FILE1)
     acl2=$($EXACL -n $FILE2)
     assertEquals "$acl1" "$acl2"

--- a/tests/testsuite_linux.sh
+++ b/tests/testsuite_linux.sh
@@ -148,8 +148,8 @@ testReadAclForFile1() {
     setfacl -b "$FILE1"
 }
 
-testReadAclForFile1_Numeric() {
-    # Same as above, but uses --numeric option.
+testReadAclForFile1_Native() {
+    # Same as above, but uses --native option.
     msg=$($EXACL -n $FILE1)
     assertEquals "exit1" 0 $?
     assertEquals \
@@ -758,7 +758,7 @@ testWriteAclToFile1_LabTest() {
         "${msg//\"/}"
 }
 
-testWriteAclToFile1_LabTestNumeric() {
+testWriteAclToFile1_LabTestNative() {
     # The 3 required entries for Linux.
     required=$(quotifyJson "[{kind:user,name:,perms:[read,write],flags:[],allow:true},{kind:group,name:,perms:[],flags:[],allow:true},{kind:other,name:,perms:[],flags:[],allow:true}]")
 
@@ -844,7 +844,7 @@ testCopyAcl_LabTest() {
     assertEquals 0 $?
     assertEquals "" "$msg"
 
-    # Numeric ACL's are equal.
+    # Native ACL's are equal.
     acl1=$($EXACL -n $FILE1)
     acl2=$($EXACL -n $FILE2)
     assertEquals "$acl1" "$acl2"


### PR DESCRIPTION
Rename all references to `numeric` to `native`.